### PR TITLE
20181227 marcoct general mh

### DIFF
--- a/docs/mcmc.tex
+++ b/docs/mcmc.tex
@@ -19,14 +19,15 @@
 
 \maketitle
 
-This document shows that Gen's \texttt{general\_mh} operator satisfies detailed balance, given that its requirements are satisfied, and given that only discrete random choices are made.
+\section{Discrete Random Choices Only}
+This section shows that Gen's \texttt{general\_mh} operator satisfies detailed balance, given that its requirements are satisfied, and given that only discrete random choices are made.
 
 \paragraph{Requirements for \texttt{general\_mh}}
 Let $p(t; x)$ denote the distribution on assignments $t$ of the model generative function, parametrized by arguments $x \in X$.
 Let $q(u; t, x, y)$ denote the distribution on assignments $u$ of the proposal generative function, parametrized by a model assignment $t$, model arguments $x$, and proposal arguments $y \in Y$.
 A proposal distribution must be defined for all $(x, y, t)$ such that $x \in X$, $y \in Y$, and $p(t; x) > 0$.
 For some $x \in X$ and $y \in Y$, let $Z_{x,y} = \{(t, u) : p(t; x) > 0, q(u; t, x, y) > 0\}$.
-We also require a bijection $f_{x,y} : Z_{x,y} \to Z_{x,y}$ such that $f^{-1}_{x,y} = f_{x,y}$ (i.e. $f_{x,y}$ is its own inverse).
+We also require a bijection $f_{x,y} : Z_{x,y} \to Z_{x,y}$ such that $f^{-1}_{x,y} = f_{x,y}$ (i.e. $f_{x,y}$ is its own inverse or an `involution').
 Let $f_{x,y}(t, u) = (f^T_{x,y}(t, u), f^U_{x,y}(t, u))$.
 
 \paragraph{The \texttt{general\_mh} procedure}
@@ -71,5 +72,12 @@ Next, consider the terms on both sides of Equation~(\ref{eq:db}) that are associ
 \end{align}
 If $t \ne t'$ then we have $\delta(t, t') = \delta(t', t) = 0$ and we are done.
 If $t = t'$ then renaming $u'$ to $u$ on the right-hand side gives the equivalance.
+
+\section{Including Continuous Random Choices}
+To extend \texttt{general\_mh} to handle continuous random choices, we need to require further structure on the involution $f_{x,y}$.
+In particular, we require that $f_{x,y}$ can be decomposed into (i) an involution $f_{x,y,\mathrm{disc}} = f_{x,y,\mathrm{disc}}^{-1}$ on the discrete random choices, and (ii) a family of diffeomorphisms on the continuous random choices, indexed by assignments to the discrete random choices.
+For any value $d$ of the discrete random choices, we require a bijection $f_{x,y,\mathrm{cont},d}$ on the such that $f^{-1}_{x,y,\mathrm{cont},d}$ = $f_{x,y,\mathrm{cont},f_{x,y,\mathrm{disc}}(d)}$.
+Then, the involution $(d', r') = f_{x,y}(d, r)$ where $d, d'$ are the previous and new assignments to the discrete-valued choices, and $r, r'$ are the previous and new assignments to the continuous random choices, is constructed by first evaluating $d' = f_{x,y,\mathrm{disc}}(d)$ and then by evaluating $r' = f_{x,y,\mathrm{cont},d}(r)$.
+The log-determinant of the Jacobian matrix of $f_{x,y,\mathrm{cont},d}$ is evaluated at $r$ and added to the log acceptance ratio.
 
 \end{document}

--- a/examples/coal/coal.jl
+++ b/examples/coal/coal.jl
@@ -111,16 +111,21 @@ end
 # model #
 #########
 
+const K = :k
+const EVENTS = :events
+const CHANGEPT = :changept
+const RATE = :rate
+
 @gen function model(T::Float64)
 
     # prior on number of change points
-    k = @addr(poisson(3.), :k)
+    k = @addr(poisson(3.), K)
 
     # prior on the location of (sorted) change points
     change_pts = Vector{Float64}(undef, k)
     lower = 0.
     for i=1:k
-        cp = @addr(min_uniform_continuous(lower, T, k-i+1), "cp$i")
+        cp = @addr(min_uniform_continuous(lower, T, k-i+1), (CHANGEPT, i))
         change_pts[i] = cp
         lower = cp
     end
@@ -129,26 +134,26 @@ end
     # h$i is the rate for cp$(i-1) to cp$i where cp0 := 0 and where cp$(k+1) := T
     alpha = 1.
     beta = 200.
-    rates = Float64[@addr(Gen.gamma(alpha, 1. / beta), "h$i") for i=1:k+1]
+    rates = Float64[@addr(Gen.gamma(alpha, 1. / beta), (RATE, i)) for i=1:k+1]
 
     # poisson process
     bounds = vcat([0.], change_pts, [T])
-    @addr(piecewise_poisson_process(bounds, rates), "points")
+    @addr(piecewise_poisson_process(bounds, rates), EVENTS)
 end
 
 function render(trace; ymax=0.02)
     T = get_args(trace)[1]
-    assignment = get_assmt(trace)
-    k = assignment[:k]
-    bounds = vcat([0.], sort([assignment["cp$i"] for i=1:k]), [T])
-    rates = [assignment["h$i"] for i=1:k+1]
+    assmt = get_assmt(trace)
+    k = assmt[:k]
+    bounds = vcat([0.], sort([assmt[(CHANGEPT, i)] for i=1:k]), [T])
+    rates = [assmt[(RATE, i)] for i=1:k+1]
     for i=1:length(rates)
         lower = bounds[i]
         upper = bounds[i+1]
         rate = rates[i]
         plot([lower, upper], [rate, rate], color="black", linewidth=2)
     end
-    points = assignment["points"]
+    points = assmt[EVENTS]
     scatter(points, -rand(length(points)) * (ymax/5.), color="black", s=5)
     ax = gca()
     xlim = [0., T]
@@ -171,32 +176,39 @@ function show_prior_samples()
 end
 
 
-###############
-# height move #
-###############
+#############
+# rate move #
+#############
 
-@gen function height_proposal(trace)
+@gen function rate_proposal(trace)
     assmt = get_assmt(trace)
-    k = assmt[:k]
-    i = @addr(uniform_discrete(1, k+1), :i)
-    height = assmt["h$i"]
-    @addr(uniform_continuous(height/2., height*2.), :height)
+
+    # pick a random segment whose rate to change
+    i = @addr(uniform_discrete(1, assmt[K]+1), :i)
+
+    # propose new value for the rate
+    cur_rate = assmt[(RATE, i)]
+    @addr(uniform_continuous(cur_rate/2., cur_rate*2.), :new_rate)
 end
 
-function height_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_args::Tuple)
+# it is an involution because it:
+# - maintains i = fwd_assmt[:i] constant
+# - swaps assmt[(RATE, i)] with fwd_assmt[:new_rate]
+
+function rate_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_args::Tuple)
     assmt = get_assmt(trace)
     model_args = get_args(trace)
     bwd_assmt = DynamicAssignment()
     constraints = DynamicAssignment()
     i = fwd_assmt[:i]
     bwd_assmt[:i] = i
-    constraints["h$i"] = fwd_assmt[:height]
-    bwd_assmt[:height] = assmt["h$i"]
+    constraints[(RATE, i)] = fwd_assmt[:new_rate]
+    bwd_assmt[:new_rate] = assmt[(RATE, i)]
     (new_trace, weight, _, _) = force_update(model_args, noargdiff, trace, constraints)
     (new_trace, bwd_assmt, weight)
 end
 
-height_move(trace) = general_mh(trace, height_proposal, (), height_involution)
+rate_move(trace) = general_mh(trace, rate_proposal, (), rate_involution)
 
 
 #################
@@ -205,12 +217,20 @@ height_move(trace) = general_mh(trace, height_proposal, (), height_involution)
 
 @gen function position_proposal(trace)
     assmt = get_assmt(trace)
-    k = assmt[:k]
+    k = assmt[K]
+    @assert k > 0
+
+    # pick a random changepoint to change
     i = @addr(uniform_discrete(1, k), :i)
-    lower = (i == 1) ? 0. : assmt["cp$(i-1)"]
-    upper = (i == k) ? T : assmt["cp$(i+1)"]
-    @addr(uniform_continuous(lower, upper), :cp)
+
+    lower = (i == 1) ? 0. : assmt[(CHANGEPT, i-1)]
+    upper = (i == k) ? T : assmt[(CHANGEPT, i+1)]
+    @addr(uniform_continuous(lower, upper), :new_changept)
 end
+
+# it is an involution because it:
+# - maintains i = fwd_assmt[:i] constant
+# - swaps assmt[(CHANGEPT, i)] with fwd_assmt[:new_changept]
 
 function position_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_args::Tuple)
     assmt = get_assmt(trace)
@@ -219,8 +239,8 @@ function position_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_arg
     constraints = DynamicAssignment()
     i = fwd_assmt[:i]
     bwd_assmt[:i] = i
-    constraints["cp$i"] = fwd_assmt[:cp]
-    bwd_assmt[:cp] = assmt["cp$i"]
+    constraints[(CHANGEPT, i)] = fwd_assmt[:new_changept]
+    bwd_assmt[:new_changept] = assmt[(CHANGEPT, i)]
     (new_trace, weight, _, _) = force_update(model_args, noargdiff, trace, constraints)
     (new_trace, bwd_assmt, weight)
 end
@@ -232,60 +252,76 @@ position_move(trace) = general_mh(trace, position_proposal, (), position_involut
 # birth / death move #
 ######################
 
+const CHOSEN = :chosen
+const IS_BIRTH = :is_birth
+const NEW_CHANGEPT = :new_changept
+const U = :u
+
 @gen function birth_death_proposal(trace)
     T = get_args(trace)[1]
     assmt = get_assmt(trace)
-    k = assmt[:k]
-    if k == 0
-        # birth only
-        isbirth = true
-    else
-        # randomly choose birth or death
-        isbirth = @addr(bernoulli(0.5), :isbirth)
-    end
+    k = assmt[K]
+
+    # if k = 0, then always do a birth move
+    # if k > 0, then randomly choose a birth or death move
+    isbirth = (k == 0) ? true : @addr(bernoulli(0.5), IS_BIRTH)
+
     if isbirth
-        i = @addr(uniform_discrete(1, k+1), :i)
-        lower = (i == 1) ? 0. : assmt["cp$(i-1)"]
-        upper = (i == k+1) ? T : assmt["cp$i"]
-        @addr(uniform_continuous(lower, upper), :cp_new)
-        @addr(uniform_continuous(0., 1.), :u)
+        # pick the segment in which to insert the new changepoint
+        # changepoints before move:  | 1     2    3 |
+        # new changepoint (i = 2):   |    *         |
+        # changepoints after move:   | 1  2  3    4 |
+        i = @addr(uniform_discrete(1, k+1), CHOSEN)
+        lower = (i == 1) ? 0. : assmt[(CHANGEPT, i-1)]
+        upper = (i == k+1) ? T : assmt[(CHANGEPT, i)]
+        @addr(uniform_continuous(lower, upper), NEW_CHANGEPT)
+        @addr(uniform_continuous(0., 1.), U)
     else
-        @addr(uniform_discrete(1, k), :i)
+        # pick the changepoint to be deleted
+        # changepoints before move:     | 1  2  3    4 |
+        # deleted changepoint (i = 2):  |    *         |
+        # changepoints after move:      | 1     2    3 |
+        @addr(uniform_discrete(1, k), CHOSEN)
     end
 end
 
-function new_heights(arr)
-    (cur_height, u, cur_cp, prev_cp, next_cp) = arr
+function new_rates(arr)
+    (cur_rate, u, cur_cp, prev_cp, next_cp) = arr
     d_prev = cur_cp - prev_cp
     d_next = next_cp - cur_cp
     @assert d_prev > 0
     @assert d_next > 0
     d_total = d_prev + d_next
-    log_cur_height = log(cur_height)
+    log_cur_rate = log(cur_rate)
     log_ratio = log(1 - u) - log(u)
-    prev_height = exp(log_cur_height - (d_next / d_total) * log_ratio)
-    next_height = exp(log_cur_height + (d_prev / d_total) * log_ratio)
-    @assert prev_height > 0.
-    @assert next_height > 0.
-    [prev_height, next_height]
+    prev_rate = exp(log_cur_rate - (d_next / d_total) * log_ratio)
+    next_rate = exp(log_cur_rate + (d_prev / d_total) * log_ratio)
+    @assert prev_rate > 0.
+    @assert next_rate > 0.
+    [prev_rate, next_rate]
 end
 
-function new_heights_inverse(arr)
-    (prev_height, next_height, cur_cp, prev_cp, next_cp) = arr
+function new_rates_inverse(arr)
+    (prev_rate, next_rate, cur_cp, prev_cp, next_cp) = arr
     d_prev = cur_cp - prev_cp
     d_next = next_cp - cur_cp
     @assert d_prev > 0
     @assert d_next > 0
     d_total = d_prev + d_next
-    log_prev_height = log(prev_height)
-    log_next_height = log(next_height)
-    cur_height = exp((d_prev / d_total) * log_prev_height + (d_next / d_total) * log_next_height)
-    u = prev_height / (prev_height + next_height)
-    @assert cur_height > 0.
-    [cur_height, u]
+    log_prev_rate = log(prev_rate)
+    log_next_rate = log(next_rate)
+    cur_rate = exp((d_prev / d_total) * log_prev_rate + (d_next / d_total) * log_next_rate)
+    u = prev_rate / (prev_rate + next_rate)
+    @assert cur_rate > 0.
+    [cur_rate, u]
 end
 
-# involution from (t, u) to (t', u')
+# it is an involution because:
+# - it switches back and forth between birth move and death move
+# - it maintains fwd_assmt[CHOSEN] constant (applying it twice will first insert a new
+#   changepoint and then remove that same changepoint)
+# - new_rates, curried on cp_new, cp_prev, and cp_next, is the inverse of new_rates_inverse.
+
 function birth_death_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_args::Tuple)
     assmt = get_assmt(trace)
     model_args = get_args(trace)
@@ -294,75 +330,77 @@ function birth_death_involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_
     bwd_assmt = DynamicAssignment()
 
     # current number of changepoints
-    k = assmt[:k]
+    k = assmt[K]
     
     # if k == 0, then we can only do a birth move
-    isbirth = (k == 0) || fwd_assmt[:isbirth]
+    isbirth = (k == 0) || fwd_assmt[IS_BIRTH]
+
+    # if we are a birth move, the inverse is a death move
     if k > 1 || isbirth
-        bwd_assmt[:isbirth] = !isbirth
+        bwd_assmt[IS_BIRTH] = !isbirth
     end
     
     # the changepoint to be added or deleted
-    i = fwd_assmt[:i]
-    bwd_assmt[:i] = i
+    i = fwd_assmt[CHOSEN]
+    bwd_assmt[CHOSEN] = i
 
     # populate constraints
     constraints = DynamicAssignment()
     if isbirth
-        constraints[:k] = k + 1
+        constraints[K] = k + 1
 
-        cp_new = fwd_assmt[:cp_new]
-        cp_prev = (i == 1) ? 0. : assmt["cp$(i-1)"]
-        cp_next = (i == k+1) ? T : assmt["cp$i"]
+        cp_new = fwd_assmt[NEW_CHANGEPT]
+        cp_prev = (i == 1) ? 0. : assmt[(CHANGEPT, i-1)]
+        cp_next = (i == k+1) ? T : assmt[(CHANGEPT, i)]
 
         # set new changepoint
-        constraints["cp$i"] = cp_new
+        constraints[(CHANGEPT, i)] = cp_new
 
         # shift up changepoints
         for j=i+1:k+1
-            constraints["cp$j"] = assmt["cp$(j-1)"]
+            constraints[(CHANGEPT, j)] = assmt[(CHANGEPT, j-1)]
         end
 
-        # compute new heights
-        h_cur = assmt["h$i"]
-        u = fwd_assmt[:u]
-        (h_prev, h_next) = new_heights([h_cur, u, cp_new, cp_prev, cp_next])
-        J = ReverseDiff.jacobian(new_heights, [h_cur, u, cp_new, cp_prev, cp_next])[:,1:2]
+        # compute new rates
+        h_cur = assmt[(RATE, i)]
+        u = fwd_assmt[U]
+        (h_prev, h_next) = new_rates([h_cur, u, cp_new, cp_prev, cp_next])
+        J = ReverseDiff.jacobian(new_rates, [h_cur, u, cp_new, cp_prev, cp_next])[:,1:2]
 
-        # set new heights
-        constraints["h$i"] = h_prev
-        constraints["h$(i+1)"] = h_next
+        # set new rates
+        constraints[(RATE, i)] = h_prev
+        constraints[(RATE, i+1)] = h_next
 
-        # shift up heights
+        # shift up rates
         for j=i+2:k+2
-            constraints["h$j"] = assmt["h$(j-1)"]
+            constraints[(RATE, j)] = assmt[(RATE, j-1)]
         end
     else
-        constraints[:k] = k - 1
+        constraints[K] = k - 1
 
-        cp_new = assmt["cp$i"]
-        cp_prev = (i == 1) ? 0. : assmt["cp$(i-1)"]
-        cp_next = (i == k) ? T : assmt["cp$(i+1)"]
-        bwd_assmt[:cp_new] = cp_new
+        cp_deleted = assmt[(CHANGEPT, i)]
+        cp_prev = (i == 1) ? 0. : assmt[(CHANGEPT, i-1)]
+        cp_next = (i == k) ? T : assmt[(CHANGEPT, i+1)]
+        bwd_assmt[NEW_CHANGEPT] = cp_deleted 
 
         # shift down changepoints
         for j=i:k-1
-            constraints["cp$j"] = assmt["cp$(j+1)"]
+            constraints[(CHANGEPT, j)] = assmt[(CHANGEPT, j+1)]
         end
 
-        # compute cur height and u
-        h_prev = assmt["h$i"]
-        h_next = assmt["h$(i+1)"]
-        (h_cur, u) = new_heights_inverse([h_prev, h_next, cp_new, cp_prev, cp_next])
-        J = ReverseDiff.jacobian(new_heights_inverse, [h_prev, h_next, cp_new, cp_prev, cp_next])[:,1:2]
-        bwd_assmt[:u] = u
+        # compute cur rate and u
+        h_prev = assmt[(RATE, i)]
+        h_next = assmt[(RATE, i+1)]
+        (h_cur, u) = new_rates_inverse([h_prev, h_next, cp_deleted, cp_prev, cp_next])
+        J = ReverseDiff.jacobian(new_rates_inverse, [h_prev, h_next, cp_deleted, cp_prev, cp_next])[:,1:2]
+        bwd_assmt[U] = u
 
-        # set cur height
-        constraints["h$i"] = h_cur
+        # set cur rate
+        constraints[(RATE, i)] = h_cur
 
-        # shift down heights
+        # shift down rates
         for j=i+1:k
-            constraints["h$j"] = assmt["h$(j+1)"]
+            constraints[(RATE, j)] = assmt[(RATE, j+1)]
         end
     end
 
@@ -373,8 +411,8 @@ end
 birth_death_move(trace) = general_mh(trace, birth_death_proposal, (), birth_death_involution)
 
 function mcmc_step(trace)
-    k = get_assmt(trace)[:k]
-    (trace, _) = height_move(trace)
+    k = get_assmt(trace)[K]
+    (trace, _) = rate_move(trace)
     if k > 0
         (trace, _) = position_move(trace)
     end
@@ -383,8 +421,8 @@ function mcmc_step(trace)
 end
 
 function simple_mcmc_step(trace)
-    k = get_assmt(trace)[:k]
-    (trace, _) = height_move(trace)
+    k = get_assmt(trace)[K]
+    (trace, _) = rate_move(trace)
     if k > 0
         (trace, _) = position_move(trace)
     end
@@ -395,7 +433,7 @@ end
 function do_mcmc(T, num_steps::Int)
     (trace, _) = initialize(model, (T,), observations)
     for iter=1:num_steps
-        k = get_assmt(trace)[:k]
+        k = get_assmt(trace)[K]
         if iter % 1000 == 0
             println("iter $iter of $num_steps, k: $k")
         end
@@ -404,12 +442,12 @@ function do_mcmc(T, num_steps::Int)
     trace
 end
 
-const k_selection = select(:k)
+const k_selection = select(K)
 
 function do_simple_mcmc(T, num_steps::Int)
     (trace, _) = initialize(model, (T,), observations)
     for iter=1:num_steps
-        k = get_assmt(trace)[:k]
+        k = get_assmt(trace)[K]
         if iter % 1000 == 0
             println("iter $iter of $num_steps, k: $k")
         end
@@ -438,7 +476,7 @@ end
 const points = load_data_set()
 const T = maximum(points)
 const observations = DynamicAssignment()
-observations["points"] = points
+observations[EVENTS] = points
 
 function show_posterior_samples()
     figure(figsize=(16,16))
@@ -463,10 +501,10 @@ function show_posterior_samples()
 end
 
 function get_rate_vector(trace, test_points)
-    assignment = get_assmt(trace)
-    k = assignment[:k]
-    cps = [assignment["cp$i"] for i=1:k]
-    hs = [assignment["h$i"] for i=1:k+1]
+    assmt = get_assmt(trace)
+    k = assmt[K]
+    cps = [assmt[(CHANGEPT, i)] for i=1:k]
+    hs = [assmt[(RATE, i)] for i=1:k+1]
     rate = Vector{Float64}()
     cur_h_idx = 1
     cur_h = hs[cur_h_idx]
@@ -490,15 +528,15 @@ function plot_posterior_mean_rate()
     test_points = collect(1.0:10.0:T)
     rates = Vector{Vector{Float64}}()
     num_samples = 0
-    num_steps = 20000
+    num_steps = 8000
     for reps=1:20
         (trace, _) = initialize(model, (T,), observations)
         for iter=1:num_steps
             if iter % 1000 == 0
-                println("iter $iter of $num_steps, k: $(get_assmt(trace)[:k])")
+                println("iter $iter of $num_steps, k: $(get_assmt(trace)[K])")
             end
             trace = mcmc_step(trace)
-            if iter > 5000
+            if iter > 4000
                 num_samples += 1
                 rate_vector = get_rate_vector(trace, test_points)
                 @assert length(rate_vector) == length(test_points)
@@ -527,13 +565,13 @@ function plot_trace_plot()
 
     # reversible jump
     (trace, _) = initialize(model, (T,), observations)
-    height1 = Float64[]
+    rate1 = Float64[]
     num_clusters_vec = Int[]
     burn_in = 0
     for iter=1:burn_in + 1000 
         trace = mcmc_step(trace)
         if iter > burn_in
-            push!(num_clusters_vec, get_assmt(trace)[:k])
+            push!(num_clusters_vec, get_assmt(trace)[K])
         end
     end
     subplot(2, 1, 1)
@@ -541,13 +579,13 @@ function plot_trace_plot()
 
     # simple MCMC
     (trace, _) = initialize(model, (T,), observations)
-    height1 = Float64[]
+    rate1 = Float64[]
     num_clusters_vec = Int[]
     burn_in = 0
     for iter=1:burn_in + 1000 
         trace = simple_mcmc_step(trace)
         if iter > burn_in
-            push!(num_clusters_vec, get_assmt(trace)[:k])
+            push!(num_clusters_vec, get_assmt(trace)[K])
         end
     end
     subplot(2, 1, 2)

--- a/examples/gp_structure/lightweight.jl
+++ b/examples/gp_structure/lightweight.jl
@@ -65,18 +65,41 @@ end
     return covariance_fn
 end
 
-@gen function subtree_proposal(prev_trace, root::Int)
-    @addr(covariance_prior(root), :tree)
-end
-
 @gen function noise_proposal(prev_trace)
     @addr(gamma(1, 1), :noise)
 end
 
-function correction(prev_trace, new_trace)
-    prev_size = size(get_retval(prev_trace))
-    new_size = size(get_retval(new_trace))
-    log(prev_size) - log(new_size)
+@gen function subtree_proposal(prev_trace)
+    prev_subtree_node::Node = get_retval(prev_trace)
+    (subtree_idx::Int, depth::Int) = @addr(pick_random_node(prev_subtree_node, 1, 0), :choose_subtree_root)
+    new_subtree_node::Node = @addr(covariance_prior(subtree_idx), :subtree)
+    (subtree_idx, depth, new_subtree_node)
+end
+
+function subtree_involution(trace, fwd_assmt::Assignment, fwd_ret::Tuple, proposal_args::Tuple)
+    (subtree_idx, subtree_depth, new_subtree_node) = fwd_ret
+    model_args = get_args(trace)
+
+    # populate constraints
+    constraints = DynamicAssignment()
+    set_subassmt!(constraints, :tree, get_subassmt(fwd_assmt, :subtree))
+
+    # obtain new trace and discard, which contains the previous subtree
+    (new_trace, weight, discard, _) = force_update(model_args, noargdiff, trace, constraints)
+
+    # populate backward assignment
+    bwd_assmt = DynamicAssignment()
+    set_subassmt!(bwd_assmt, :choose_subtree_root => :recurse_left,
+        get_subassmt(fwd_assmt, :choose_subtree_root => :recurse_left))
+    for depth=0:subtree_depth-1
+        bwd_assmt[:choose_subtree_root => :done => depth] = false
+    end
+    if !isa(new_subtree_node, LeafNode)
+        bwd_assmt[:choose_subtree_root => :done => subtree_depth] = true
+    end
+    set_subassmt!(bwd_assmt, :subtree, get_subassmt(discard, :tree))
+
+    (new_trace, bwd_assmt, weight)
 end
 
 function inference(xs::Vector{Float64}, ys::Vector{Float64}, num_iters::Int, callback)
@@ -97,11 +120,8 @@ function inference(xs::Vector{Float64}, ys::Vector{Float64}, num_iters::Int, cal
         noise = get_assmt(trace)[:noise]
         callback(covariance_fn, noise)
 
-        # randomly pick a node to expand
-        root = pick_random_node(covariance_fn, 1, max_branch)
-
         # do MH move on the subtree
-        (trace, _) = custom_mh(trace, subtree_proposal, (root,), correction)
+        (trace, _) = general_mh(trace, subtree_proposal, (), subtree_involution)
 
         # do MH move on the top-level white noise
         (trace, _) = custom_mh(trace, noise_proposal, ())

--- a/examples/gp_structure/lightweight.jl
+++ b/examples/gp_structure/lightweight.jl
@@ -80,14 +80,14 @@ function subtree_involution(trace, fwd_assmt::Assignment, fwd_ret::Tuple, propos
     (subtree_idx, subtree_depth, new_subtree_node) = fwd_ret
     model_args = get_args(trace)
 
-    # populate constraints
+    # populate constraints with proposed subtree
     constraints = DynamicAssignment()
     set_subassmt!(constraints, :tree, get_subassmt(fwd_assmt, :subtree))
 
     # obtain new trace and discard, which contains the previous subtree
     (new_trace, weight, discard, _) = force_update(model_args, noargdiff, trace, constraints)
 
-    # populate backward assignment
+    # populate backward assignment with choice of root
     bwd_assmt = DynamicAssignment()
     set_subassmt!(bwd_assmt, :choose_subtree_root => :recurse_left,
         get_subassmt(fwd_assmt, :choose_subtree_root => :recurse_left))
@@ -97,6 +97,8 @@ function subtree_involution(trace, fwd_assmt::Assignment, fwd_ret::Tuple, propos
     if !isa(new_subtree_node, LeafNode)
         bwd_assmt[:choose_subtree_root => :done => subtree_depth] = true
     end
+
+    # populate backward assignment with the previous subtree
     set_subassmt!(bwd_assmt, :subtree, get_subassmt(discard, :tree))
 
     (new_trace, bwd_assmt, weight)

--- a/src/dynamic_dsl/assess.jl
+++ b/src/dynamic_dsl/assess.jl
@@ -52,9 +52,9 @@ function assess(gen_fn::DynamicDSLFunction, args::Tuple, assmt::Assignment)
     state = GFAssessState(assmt, gen_fn.params)
     retval = exec(gen_fn, state, args)
 
-    visited = get_visited(state.visitor)
-    if !all_visited(visited, assmt)
-        error("Did not visit all constraints")
+    unvisited = get_unvisited(get_visited(state.visitor), assmt)
+    if !isempty(unvisited)
+        error("Assess did not visit the following constraint addresses:\n$unvisited")
     end
 
     (state.weight, retval)

--- a/src/dynamic_dsl/dynamic_dsl.jl
+++ b/src/dynamic_dsl/dynamic_dsl.jl
@@ -303,6 +303,27 @@ function all_visited(visited::AddressSet, assmt::Assignment)
     allvisited
 end
 
+function get_unvisited(visited::AddressSet, assmt::Assignment)
+    unvisited = DynamicAssignment()
+    for (key, _) in get_values_shallow(assmt)
+        if !has_leaf_node(visited, key)
+            set_value!(unvisited, key, get_value(assmt, key))
+        end
+    end
+    for (key, subassmt) in get_subassmts_shallow(assmt)
+        if !has_leaf_node(visited, key)
+            if has_internal_node(visited, key)
+                subvisited = get_internal_node(visited, key)
+            else
+                subvisited = EmptyAddressSet()
+            end
+            sub_unvisited = get_unvisited(subvisited, subassmt)
+            set_subassmt!(unvisited, key, sub_unvisited)
+        end
+    end
+    unvisited
+end
+
 get_visited(visitor) = visitor.visited
 
 function check_no_subassmt(constraints::Assignment, addr)

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -71,26 +71,34 @@ function custom_mh(trace, proposal::GenerativeFunction, proposal_args::Tuple,
 end
 
 """
+    (new_trace, accepted) = general_mh(trace, proposal::GenerativeFunction, proposal_args::Tuple, involution::Function)
 
-    (new_trace, accepted) = general_mh(trace, proposal, proposal_args, bijection)
+Perform a generalized Metropolis-Hastings update based on an involution (bijection that is its own inverse) on a space of assignments.
 
-Apply a MCMC update constructed from a bijection and a proposal that satisfies detailed balance.
+The `involution' Julia function has the following signature:
+
+    (new_trace, bwd_assmt::Assignment, weight) = involution(trace, fwd_assmt::Assignment, fwd_ret, proposal_args::Tuple)
+
+The generative function `proposal` is executed on arguments `(trace, proposal_args...)`, producing an assignment `fwd_assmt` and return value `fwd_ret`.
+For each value of model arguments (contained in `trace`) and `proposal_args`, the `involution` function applies an involution (bijection that is its own inverse) between the tuple `(get_trace(new_trace), bwd_assmt)` and the tuple `(get_trace(trace), fwd_assmt)`.
+Note that `fwd_ret` is a deterministic function of `fwd_assmt` and `proposal_args`.
+When only discrete random choices are used, the `weight` must be equal to `get_score(new_trace) - get_score(trace)`.
+
+**Including Continuous Random Choices**
+When continuous random choices are used, the `weight` must include a term contributed by the Jacobian of the bijection on the continuous random choices obtained by currying on the discrete random choices.
 """
-function general_mh(trace, proposal::GenerativeFunction, proposal_args::Tuple,
-                    bijection::Function)
-    model = get_gen_fn(trace)
-    model_args = get_args(trace)
-    model_score = get_score(trace)
-    (fwd_assmt, fwd_score, _) = propose(proposal, (trace, proposal_args...,))
-    input = pair(get_assmt(trace), fwd_assmt, :model, :proposal)
-    context = (model_args, proposal_args)
-    (output, logabsdet) = bijection(input, context)
-    (constraints, bwd_assmt) = unpair(output, :model, :proposal)
-    (new_trace, _, _, _) = force_update(model_args, noargdiff, trace, constraints)
-    new_model_score = get_score(new_trace)
+function general_mh(trace, proposal::GenerativeFunction,
+                    proposal_args::Tuple, involution::Function)
+    # run proposal forward
+    (fwd_assmt, fwd_score, fwd_ret) = propose(proposal, (trace, proposal_args...,))
+
+    # apply involution
+    (new_trace, bwd_assmt, weight) = involution(trace, fwd_assmt, fwd_ret, proposal_args)
+    
+    # assess backward proposal
     (bwd_score, _) = assess(proposal, (new_trace, proposal_args...), bwd_assmt)
-    alpha = new_model_score - model_score - fwd_score + bwd_score + logabsdet
-    if log(rand()) < alpha
+
+    if log(rand()) < weight - fwd_score + bwd_score
         # accept
         (new_trace, true)
     else

--- a/test/dynamic_dsl.jl
+++ b/test/dynamic_dsl.jl
@@ -6,6 +6,8 @@ using Gen: AddressVisitor, all_visited, visit!, get_visited
 # address visitor #
 ###################
 
+# TODO also test get_unvisited
+
 @testset "address visitor" begin
     assmt = DynamicAssignment()
     assmt[:x] = 1


### PR DESCRIPTION
Rewrite `general_mh` operator. Changes from previous versions:
- Users can now only write out only the portion of the model assignment that need to change.
- Users can implement the Jacobian computation however they want.
- The parameters are a single proposal generative function, and a single involution (self-inverse) on assignments. This is a simplification from earlier versions, in which a separate forward and reverse proposals were used, and in which the bijection was not necessarily an involution.
- The examples haven been updated to show how users can avoid manually computing a correction to the MH acceptance probability when the choice of move (called the 'move type' by P Green) is itself random.
- The `correction` callback has been removed.