### PR TITLE
20190111 marcoct addrs

### DIFF
--- a/docs/src/ref/assignments.md
+++ b/docs/src/ref/assignments.md
@@ -37,6 +37,11 @@ assmt["foo"] = 1.25
 assmt[:y => 1 => :z] = -6.3
 ```
 
+There is also a constructor for `DynamicAssignment` that takes initial (address, value) pairs:
+```julia
+assmt = DynamicAssignment((:x, true), ("foo", 1.25), (:y => 1 => :z, -6.3))
+```
+
 ```@docs
 DynamicAssignment
 set_value!

--- a/docs/src/ref/assignments.md
+++ b/docs/src/ref/assignments.md
@@ -14,6 +14,7 @@ get_values_shallow
 get_subassmts_shallow
 to_array
 from_array
+address_set
 ```
 Note that none of these methods mutate the assignment.
 

--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -48,7 +48,7 @@ function has_value end
 """
     key_subassmt_iterable = get_values_shallow(assmt::Assignment)
 
-Return an iterable collection of tuples `(key, subassmt::Assignment)` for each
+Return an iterable collection of tuples `(key, value)` for each
 top-level key associated with a value.
 """
 function get_values_shallow end
@@ -58,7 +58,7 @@ abstract type Assignment end
 """
     Base.isempty(assmt::Assignment)
 
-Return true if there are no random choices in the assignment.
+Return true if there are no values in the assignment.
 """
 function Base.isempty(::Assignment)
     true
@@ -232,17 +232,21 @@ function Base.merge(assmt1::Assignment, assmt2::Assignment)
     return assmt
 end
 
-#"""
-    #Base.values(assmt::Assignment)
-#
-#Return an iterator over all values in an assignment (the addresses are not
-#included).
-#"""
-#function Base.values(assmt::Assignment)
-    #iterators::Vector = collect(map(values, get_subassmts_shallow(assmt)))
-    #push!(iterators, values(get_values_shallow(assmt)))
-    #Iterators.flatten(iterators)
-#end
+"""
+    addrs::AddressSet = address_set(assmt::Assignment)
+
+Return an `AddressSet` containing the addresses of values in the given assignment.
+"""
+function address_set(assmt::Assignment)
+    set = DynamicAddressSet()
+    for (key, _) in get_values_shallow(assmt)
+        push_leaf_node!(set, key)
+    end
+    for (key, subassmt) in get_subassmts_shallow(assmt)
+        set_internal_node!(set, key, address_set(subassmt))
+    end
+    set
+end
 
 export Assignment
 export get_address_schema
@@ -254,6 +258,7 @@ export get_values_shallow
 export static_get_value
 export static_get_subassmt
 export to_array, from_array
+export address_set
 
 
 ######################

--- a/src/assignment.jl
+++ b/src/assignment.jl
@@ -520,10 +520,22 @@ end
 """
     assmt = DynamicAssignment()
 
-Construct an empty dynamic assignment.
+Construct an empty assignment.
+
+    assmt = DynamicAssignment(pairs...)
+
+Construct an assignment containing each of the given (addr, value) pair.
 """
 function DynamicAssignment()
     DynamicAssignment(Dict(), Dict())
+end
+
+function DynamicAssignment(pairs...)
+    assmt = DynamicAssignment()
+    for (addr, value) in pairs
+        assmt[addr] = value
+    end
+    assmt
 end
 
 get_address_schema(::Type{DynamicAssignment}) = DynamicAddressSchema()

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -287,3 +287,11 @@ end
     @test has_leaf_node(set, :y => :b)
     @test has_leaf_node(set, :y => :c => :z)
 end
+
+@testset "dynamic assignment constructor" begin
+
+    assmt = DynamicAssignment((:x, 1), (:y => :a, 2), (:y => :b, 3))
+    @test assmt[:x] == 1
+    @test assmt[:y => :a] == 2
+    @test assmt[:y => :b] == 3
+end

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -272,3 +272,18 @@ end
     try set_subassmt!(assmt, :x => :y, subassmt) catch KeyError threw = true end
     @test threw
 end
+
+@testset "address_set" begin
+
+    assmt = DynamicAssignment()
+    assmt[:x] = 1
+    assmt[:y => :a] = 2
+    assmt[:y => :b] = 3
+    assmt[:y => :c => :z] = 4
+
+    set = address_set(assmt)
+    @test has_leaf_node(set, :x)
+    @test has_leaf_node(set, :y => :a)
+    @test has_leaf_node(set, :y => :b)
+    @test has_leaf_node(set, :y => :c => :z)
+end


### PR DESCRIPTION
- add `address_set(assmt::Assignment)` method that returns an `AddressSet` containing all the keys in the given assignment
- add a constructor for `DynamicAssignment` (https://github.com/probcomp/Gen/issues/20)