### PR TITLE
refactor particle filtering

### DIFF
--- a/docs/src/ref/inference.md
+++ b/docs/src/ref/inference.md
@@ -22,8 +22,12 @@ map_optimize
 
 ## Particle Filtering
 ```@docs
-particle_filter_default
-particle_filter_custom
+initialize_particle_filter
+particle_filter_step!
+maybe_resample!
+log_ml_estimate
+traces
+log_weights
 ```
 
 ## Supervised Training


### PR DESCRIPTION
Refactor particle filtering to involve separate components that can be individually understood and composed by users, instead of inflexible monolithic functions with huge numbers of arguments.