### PR TITLE
Improve error msgs for dynamic Gen functions

### DIFF
--- a/src/dsl/dynamic.jl
+++ b/src/dsl/dynamic.jl
@@ -3,8 +3,10 @@ const DYNAMIC_DSL_TRACE = Symbol("@trace")
 function make_dynamic_gen_function(name, args, body, return_type, annotations)
     escaped_args = map((arg) -> esc(arg.name), args)
     gf_args = [esc(state), escaped_args...]
+
+    julia_fn_name = gensym(name)
     julia_fn_defn = Expr(:function,
-        Expr(:tuple, gf_args...),
+        Expr(:call, esc(julia_fn_name), gf_args...),
         esc(body))
 
     # create generator and assign it a name
@@ -13,6 +15,7 @@ function make_dynamic_gen_function(name, args, body, return_type, annotations)
         (arg) -> (DSL_ARG_GRAD_ANNOTATION in arg.annotations), args)
     accepts_output_grad = DSL_RET_GRAD_ANNOTATION in annotations
     Expr(:block,
+        julia_fn_defn,
         Expr(:(=), 
             esc(name),
             Expr(:call, :DynamicDSLFunction,


### PR DESCRIPTION
Previously, when you called a dynamic Gen function with arguments that did not match the argument signature, you got an error that did not actually include the name of the function, making it difficult to track down where the error occurred.

The code to generate the error is:
```julia
@gen function foo(x)
    x
end

println(foo(1, 2))
```

The error was previously:
```
ERROR: LoadError: MethodError: no method matching (::getfield(Main, Symbol("##3#4")))(::Gen.GFProposeState, ::Int64, ::Int64)
Closest candidates are:
  #3(::Any, ::Any) at /home/marcoct/dev/Gen/src/dsl/test.jl:4
```

Now, the error message contains the name of the function:
```
ERROR: LoadError: MethodError: no method matching ##foo#361(::Gen.GFProposeState, ::Int64, ::Int64)
Closest candidates are:
  ##foo#361(::Any, ::Any) at /home/marcoct/dev/Gen/src/dsl/test.jl:7
```