### PR TITLE
Add caching of Julia values in static IR trace by default

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -64,7 +64,9 @@ Currently the possible function annotations are:
 
 - `grad` (see [Differentiable programming](@ref)).
 
-- `static` (see [Static DSL](@ref)).
+- `static` (see [Static Modeling Language](@ref)).
+
+- `nojuliacache` (see [Static Modeling Language](@ref)).
 
 ## Making random choices
 
@@ -425,3 +427,9 @@ load_generated_functions()
 ### Performance tips
 For better performance when the arguments are simple data types like `Float64`, annotate the arguments with the concrete type.
 This permits a more optimized trace data structure to be generated for the generative function.
+
+### Caching Julia values
+
+By default, the values of Julia computations (all calls that are not random choices or calls to generative functions) are cached as part of the trace, so that [Trace update operations](@ref) can avoid unecessary re-execution of Julia code.
+However, this cache may grow the memory footprint of a trace.
+To disable caching of Julia values, use the function annotation `nojuliacache` (this annotation is ignored unless the `static` function annotation is also used).

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -2,6 +2,7 @@ const DSL_STATIC_ANNOTATION = :static
 const DSL_ARG_GRAD_ANNOTATION = :grad
 const DSL_RET_GRAD_ANNOTATION = :grad
 const DSL_TRACK_DIFFS_ANNOTATION = :diffs
+const DSL_NO_JULIA_CACHE_ANNOTATION = :nojuliacache
 
 struct Argument
     name::Symbol

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -256,7 +256,9 @@ function make_static_gen_function(name, args, body, return_type, annotations)
     expr = gensym("gen_fn_defn")
     # note: use the eval() for the user's module, not Gen
     track_diffs = DSL_TRACK_DIFFS_ANNOTATION in annotations
+    cache_julia_nodes = !(DSL_NO_JULIA_CACHE_ANNOTATION in annotations) # cache julia nodes by default
+    options = StaticIRGenerativeFunctionOptions(track_diffs, cache_julia_nodes)
     push!(stmts, :($(esc(name)) = $(esc(:eval))(
-        generate_generative_function(ir, $(QuoteNode(name)), $(QuoteNode(track_diffs))))))
+        generate_generative_function(ir, $(QuoteNode(name)), $(QuoteNode(options))))))
     Expr(:block, stmts...)
 end

--- a/src/static_ir/update.jl
+++ b/src/static_ir/update.jl
@@ -99,13 +99,15 @@ function BackwardPassState()
     BackwardPassState(Set{StaticIRNode}())
 end
 
-function process_backward!(::ForwardPassState, ::BackwardPassState, ::TrainableParameterNode) end
+function process_backward!(::ForwardPassState, ::BackwardPassState, ::TrainableParameterNode, options) end
 
-function process_backward!(::ForwardPassState, ::BackwardPassState, ::ArgumentNode) end
+function process_backward!(::ForwardPassState, ::BackwardPassState, ::ArgumentNode, options) end
 
-function process_backward!(::ForwardPassState, back::BackwardPassState,
-                           node::JuliaNode)
-    if node in back.marked
+function process_backward!(fwd::ForwardPassState, back::BackwardPassState,
+                           node::JuliaNode, options)
+    # if the node needs to be re-run which then we need the value of its inputs
+    if ((options.cache_julia_nodes && node in fwd.value_changed) ||
+        (!options.cache_julia_nodes && node in back.marked))
         for input_node in node.inputs
             push!(back.marked, input_node)
         end
@@ -113,7 +115,7 @@ function process_backward!(::ForwardPassState, back::BackwardPassState,
 end
 
 function process_backward!(fwd::ForwardPassState, back::BackwardPassState,
-                           node::RandomChoiceNode)
+                           node::RandomChoiceNode, options)
     if node in fwd.input_changed || node in fwd.constrained_or_selected_choices
         for input_node in node.inputs
             push!(back.marked, input_node)
@@ -122,7 +124,7 @@ function process_backward!(fwd::ForwardPassState, back::BackwardPassState,
 end
 
 function process_backward!(fwd::ForwardPassState, back::BackwardPassState,
-                           node::GenerativeFunctionCallNode)
+                           node::GenerativeFunctionCallNode, options)
     if node in fwd.input_changed || node in fwd.constrained_or_selected_calls
         for input_node in node.inputs
             push!(back.marked, input_node)
@@ -141,150 +143,169 @@ function arg_values_and_diffs_from_tracked_diffs(input_nodes)
 end
 
 function process_codegen!(stmts, ::ForwardPassState, back::BackwardPassState,
-                          node::TrainableParameterNode, ::AbstractUpdateMode, track_diffs)
+                          node::TrainableParameterNode, ::AbstractUpdateMode, options)
     if node in back.marked
         push!(stmts, :($(node.name) = $(QuoteNode(get_param))($(QuoteNode(get_gen_fn))(trace), $(QuoteNode(node.name)))))
     end
 end
 
 function process_codegen!(stmts, ::ForwardPassState, ::BackwardPassState,
-                          node::ArgumentNode, ::AbstractUpdateMode, track_diffs::Val{true})
-    push!(stmts, :($(get_value_fieldname(node)) = $qn_strip_diff($(node.name))))
-end
-
-function process_codegen!(stmts, ::ForwardPassState, ::BackwardPassState,
-                          node::ArgumentNode, ::AbstractUpdateMode, track_diffs::Val{false})
-    push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
-end
-
-function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
-                         node::JuliaNode, ::AbstractUpdateMode, track_diffs::Val{true})
-    if node in back.marked
-        arg_values, arg_diffs = arg_values_and_diffs_from_tracked_diffs(node.inputs)
-        args = map((v, d) -> Expr(:call, qn_Diffed, v, d), arg_values, arg_diffs)
-        push!(stmts, :($(node.name) = $(QuoteNode(node.fn))($(args...))))
+                          node::ArgumentNode, ::AbstractUpdateMode, options)
+    if options.track_diffs
+        push!(stmts, :($(get_value_fieldname(node)) = $qn_strip_diff($(node.name))))
+    else
+        push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
     end
 end
 
 function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
-                         node::JuliaNode, ::AbstractUpdateMode, track_diffs::Val{false})
-    if node in back.marked
+                         node::JuliaNode, ::AbstractUpdateMode, options)
+    run_it = ((options.cache_julia_nodes && node in fwd.value_changed) ||
+              (!options.cache_julia_nodes && node in back.marked))
+    if options.track_diffs
+
+        # track diffs
+        if run_it
+            arg_values, arg_diffs = arg_values_and_diffs_from_tracked_diffs(node.inputs)
+            args = map((v, d) -> Expr(:call, qn_Diffed, v, d), arg_values, arg_diffs)
+            push!(stmts, :($(node.name) = $(QuoteNode(node.fn))($(args...))))
+        elseif options.cache_julia_nodes
+            push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), $qn_no_change)))
+        end
+        if options.cache_julia_nodes
+            push!(stmts, :($(get_value_fieldname(node)) = $qn_strip_diff($(node.name))))
+        end
+    else
+
+        # no track diffs
+        if run_it
+            arg_values = map((n) -> n.name, node.inputs)
+            push!(stmts, :($(node.name) = $(QuoteNode(node.fn))($(arg_values...))))
+        elseif options.cache_julia_nodes
+            push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
+        end
+        if options.cache_julia_nodes
+            push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
+        end
+    end
+end
+
+function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
+                          node::RandomChoiceNode, ::Union{UpdateMode,ExtendMode},
+                          options)
+    if options.track_diffs
+
+        # track diffs
+        arg_values, _ = arg_values_and_diffs_from_tracked_diffs(node.inputs)
+        new_logpdf = gensym("new_logpdf")
+        addr = QuoteNode(node.addr)
+        dist = QuoteNode(node.dist)
+        if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
+            if node in fwd.constrained_or_selected_choices
+                push!(stmts, :($(node.name) = $qn_Diffed($qn_static_get_value(constraints, Val($addr)), $qn_unknown_change)))
+                push!(stmts, :($(choice_discard_var(node)) = trace.$(get_value_fieldname(node))))
+            else
+                push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
+            end
+            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $qn_strip_diff($(node.name)), $(arg_values...))))
+            push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
+        else
+            push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), $qn_no_change)))
+            push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
+        end
+        push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
+
+    else
+
+        # no track diffs
         arg_values = map((n) -> n.name, node.inputs)
-        push!(stmts, :($(node.name) = $(QuoteNode(node.fn))($(arg_values...))))
-    end
-end
-
-function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
-                          node::RandomChoiceNode, ::Union{UpdateMode,ExtendMode},
-                          track_diffs::Val{true})
-    arg_values, _ = arg_values_and_diffs_from_tracked_diffs(node.inputs)
-    new_logpdf = gensym("new_logpdf")
-    addr = QuoteNode(node.addr)
-    dist = QuoteNode(node.dist)
-    if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
-        if node in fwd.constrained_or_selected_choices
-            push!(stmts, :($(node.name) = $qn_Diffed($qn_static_get_value(constraints, Val($addr)), $qn_unknown_change)))
-            push!(stmts, :($(choice_discard_var(node)) = trace.$(get_value_fieldname(node))))
-        else
-            push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
-        end
-        push!(stmts, :($new_logpdf = $qn_logpdf($dist, $qn_strip_diff($(node.name)), $(arg_values...))))
-        push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
-    else
-        push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), $qn_no_change)))
-        push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
-    end
-    push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
-end
-
-function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
-                          node::RandomChoiceNode, ::Union{UpdateMode,ExtendMode},
-                          track_diffs::Val{false})
-    arg_values = map((n) -> n.name, node.inputs)
-    new_logpdf = gensym("new_logpdf")
-    addr = QuoteNode(node.addr)
-    dist = QuoteNode(node.dist)
-    if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
-        if node in fwd.constrained_or_selected_choices
-            push!(stmts, :($(node.name) = $qn_static_get_value(constraints, Val($addr))))
-            push!(stmts, :($(choice_discard_var(node)) = trace.$(get_value_fieldname(node))))
+        new_logpdf = gensym("new_logpdf")
+        addr = QuoteNode(node.addr)
+        dist = QuoteNode(node.dist)
+        if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
+            if node in fwd.constrained_or_selected_choices
+                push!(stmts, :($(node.name) = $qn_static_get_value(constraints, Val($addr))))
+                push!(stmts, :($(choice_discard_var(node)) = trace.$(get_value_fieldname(node))))
+            else
+                push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
+            end
+            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
+            push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
         else
             push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
         end
-        push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
-        push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
-    else
-        push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
+        push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
     end
-    push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
 end
 
 function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                           node::RandomChoiceNode, ::RegenerateMode,
-                          track_diffs::Val{true})
-    arg_values, _ = arg_values_and_diffs_from_tracked_diffs(node.inputs)
-    new_logpdf = gensym("new_logpdf")
-    addr = QuoteNode(node.addr)
-    dist = QuoteNode(node.dist)
-    if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
-        output_value = Expr(:call, qn_strip_diff, node.name)
-        if node in fwd.constrained_or_selected_choices
-            # the choice was selected, it does not contribute to the weight
-            push!(stmts, :($(node.name) = $qn_Diffed($qn_random($dist, $(arg_values...)), UnknownChange())))
-            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $output_value, $(arg_values...))))
-        else
-            # the choice was not selected, and the input to the choice changed
-            # it does contribute to the weight
-            push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
-            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $output_value, $(arg_values...))))
-            push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
-        end
-        push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
-    else
-        push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
-        push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
-    end
-    push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
-end
+                          options)
+    if options.track_diffs
 
-function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
-                          node::RandomChoiceNode, ::RegenerateMode,
-                          track_diffs::Val{false})
-    arg_values = map((n) -> n.name, node.inputs)
-    new_logpdf = gensym("new_logpdf")
-    addr = QuoteNode(node.addr)
-    dist = QuoteNode(node.dist)
-    if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
-        if node in fwd.constrained_or_selected_choices
-            # the choice was selected, it does not contribute to the weight
-            push!(stmts, :($(node.name) = $qn_random($dist, $(arg_values...))))
-            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
+        # track diffs
+        arg_values, _ = arg_values_and_diffs_from_tracked_diffs(node.inputs)
+        new_logpdf = gensym("new_logpdf")
+        addr = QuoteNode(node.addr)
+        dist = QuoteNode(node.dist)
+        if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
+            output_value = Expr(:call, qn_strip_diff, node.name)
+            if node in fwd.constrained_or_selected_choices
+                # the choice was selected, it does not contribute to the weight
+                push!(stmts, :($(node.name) = $qn_Diffed($qn_random($dist, $(arg_values...)), UnknownChange())))
+                push!(stmts, :($new_logpdf = $qn_logpdf($dist, $output_value, $(arg_values...))))
+            else
+                # the choice was not selected, and the input to the choice changed
+                # it does contribute to the weight
+                push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
+                push!(stmts, :($new_logpdf = $qn_logpdf($dist, $output_value, $(arg_values...))))
+                push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
+            end
+            push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
         else
-            # the choice was not selected, and the input to the choice changed
-            # it does contribute to the weight
-            push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
-            push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
-            push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($(node.name) = $qn_Diffed(trace.$(get_value_fieldname(node)), NoChange())))
+            push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
         end
-        push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
+        push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
     else
-        push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
-        push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
+
+        # no track diffs
+        arg_values = map((n) -> n.name, node.inputs)
+        new_logpdf = gensym("new_logpdf")
+        addr = QuoteNode(node.addr)
+        dist = QuoteNode(node.dist)
+        if node in fwd.constrained_or_selected_choices || node in fwd.input_changed
+            if node in fwd.constrained_or_selected_choices
+                # the choice was selected, it does not contribute to the weight
+                push!(stmts, :($(node.name) = $qn_random($dist, $(arg_values...))))
+                push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
+            else
+                # the choice was not selected, and the input to the choice changed
+                # it does contribute to the weight
+                push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
+                push!(stmts, :($new_logpdf = $qn_logpdf($dist, $(node.name), $(arg_values...))))
+                push!(stmts, :($weight += $new_logpdf - trace.$(get_score_fieldname(node))))
+            end
+            push!(stmts, :($total_score_fieldname += $new_logpdf - trace.$(get_score_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = $new_logpdf))
+        else
+            push!(stmts, :($(node.name) = trace.$(get_value_fieldname(node))))
+            push!(stmts, :($(get_score_fieldname(node)) = trace.$(get_score_fieldname(node))))
+        end
+        push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
     end
-    push!(stmts, :($(get_value_fieldname(node)) = $(node.name)))
 end
 
 function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                           node::GenerativeFunctionCallNode, ::UpdateMode,
-                          track_diffs::Val)
-    if isa(track_diffs, Val{true})
+                          options)
+    if options.track_diffs
         arg_values, arg_diffs = arg_values_and_diffs_from_tracked_diffs(node.inputs)
     else
         arg_values = map((n) -> n.name, node.inputs)
@@ -311,14 +332,14 @@ function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                             $num_nonempty_fieldname += 1 end))
         push!(stmts, :(if $qn_isempty($qn_get_choices($subtrace)) && !$qn_isempty($qn_get_choices($prev_subtrace))
                             $num_nonempty_fieldname -= 1 end))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $(calldiff_var(node)))))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
         end
     else
         push!(stmts, :($subtrace = $prev_subtrace))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $(QuoteNode(NoChange())))))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
@@ -328,8 +349,8 @@ end
 
 function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                           node::GenerativeFunctionCallNode, ::RegenerateMode,
-                          track_diffs::Val)
-    if isa(track_diffs, Val{true})
+                          options)
+    if options.track_diffs
         arg_values, arg_diffs = arg_values_and_diffs_from_tracked_diffs(node.inputs)
     else
         arg_values = map((n) -> n.name, node.inputs)
@@ -356,14 +377,14 @@ function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                             $num_nonempty_fieldname += 1 end))
         push!(stmts, :(if $qn_isempty($qn_get_choices($subtrace)) && !$qn_isempty($qn_get_choices($prev_subtrace))
                             $num_nonempty_fieldname -= 1 end))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $(calldiff_var(node)))))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
         end
     else
         push!(stmts, :($subtrace = $prev_subtrace))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $qn_no_change)))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
@@ -373,8 +394,8 @@ end
 
 function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                           node::GenerativeFunctionCallNode, ::ExtendMode,
-                          track_diffs::Val)
-    if isa(track_diffs, Val{true})
+                          options)
+    if options.track_diffs
         arg_values, arg_diffs = arg_values_and_diffs_from_tracked_diffs(node.inputs)
     else
         arg_values = map((n) -> n.name, node.inputs)
@@ -402,14 +423,14 @@ function process_codegen!(stmts, fwd::ForwardPassState, back::BackwardPassState,
                             $num_nonempty_fieldname += 1 end))
         push!(stmts, :(if $qn_isempty($qn_get_choices($subtrace)) && !$qn_isempty($qn_get_choices($prev_subtrace))
                             $num_nonempty_fieldname -= 1 end))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $(calldiff_var(node)))))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
         end
     else
         push!(stmts, :($subtrace = $prev_subtrace))
-        if isa(track_diffs, Val{true})
+        if options.track_diffs
             push!(stmts, :($(node.name) = $qn_Diffed($qn_get_retval($subtrace), $qn_no_change)))
         else
             push!(stmts, :($(node.name) = $qn_get_retval($subtrace)))
@@ -424,37 +445,37 @@ function initialize_score_weight_num_nonempty!(stmts::Vector{Expr})
     push!(stmts, :($num_nonempty_fieldname = trace.$num_nonempty_fieldname))
 end
 
-function unpack_arguments!(stmts::Vector{Expr}, arg_nodes::Vector{ArgumentNode}, track_diffs::Val{true})
-    arg_names = Symbol[arg_node.name for arg_node in arg_nodes]
-    push!(stmts, :($(Expr(:tuple, arg_names...)) = $(QuoteNode(map))($qn_Diffed, args, argdiffs)))
+function unpack_arguments!(stmts::Vector{Expr}, arg_nodes::Vector{ArgumentNode}, options)
+    if options.track_diffs
+        arg_names = Symbol[arg_node.name for arg_node in arg_nodes]
+        push!(stmts, :($(Expr(:tuple, arg_names...)) = $(QuoteNode(map))($qn_Diffed, args, argdiffs)))
+    else
+        arg_names = Symbol[arg_node.name for arg_node in arg_nodes]
+        push!(stmts, :($(Expr(:tuple, arg_names...)) = args))
+    end
 end
 
-function unpack_arguments!(stmts::Vector{Expr}, arg_nodes::Vector{ArgumentNode}, track_diffs::Val{false})
-    arg_names = Symbol[arg_node.name for arg_node in arg_nodes]
-    push!(stmts, :($(Expr(:tuple, arg_names...)) = args))
+function generate_return_value!(stmts::Vector{Expr}, fwd::ForwardPassState, return_node::StaticIRNode, options)
+    if options.track_diffs
+        push!(stmts, :($return_value_fieldname = $qn_strip_diff($(return_node.name))))
+        push!(stmts, :($retdiff = $qn_get_diff($(return_node.name))))
+    else
+        push!(stmts, :($return_value_fieldname = $(return_node.name)))
+        push!(stmts, :($retdiff = $(QuoteNode(return_node in fwd.value_changed ? UnknownChange() : NoChange()))))
+    end
 end
 
-function generate_return_value!(stmts::Vector{Expr}, fwd::ForwardPassState, return_node::StaticIRNode, track_diffs::Val{true})
-    push!(stmts, :($return_value_fieldname = $qn_strip_diff($(return_node.name))))
-    push!(stmts, :($retdiff = $qn_get_diff($(return_node.name))))
-end
-
-function generate_return_value!(stmts::Vector{Expr}, fwd::ForwardPassState, return_node::StaticIRNode, track_diffs::Val{false})
-    push!(stmts, :($return_value_fieldname = $(return_node.name)))
-    push!(stmts, :($retdiff = $(QuoteNode(return_node in fwd.value_changed ? UnknownChange() : NoChange()))))
-end
-
-function generate_new_trace!(stmts::Vector{Expr}, trace_type::Type, track_diffs::Val{true})
-    # note that the generative function is the last field
-    constructor_args = map((name) -> Expr(:call, QuoteNode(strip_diff), name), 
-                           fieldnames(trace_type)[1:end-1])
-    push!(stmts, :($trace = $(QuoteNode(trace_type))($(constructor_args...),
-                    $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref))))))
-end
-
-function generate_new_trace!(stmts::Vector{Expr}, trace_type::Type, track_diffs::Val{false})
-    push!(stmts, :($static_ir_gen_fn_ref = $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref)))))
-    push!(stmts, :($trace = $(QuoteNode(trace_type))($(fieldnames(trace_type)...))))
+function generate_new_trace!(stmts::Vector{Expr}, trace_type::Type, options)
+    if options.track_diffs
+        # note that the generative function is the last field
+        constructor_args = map((name) -> Expr(:call, QuoteNode(strip_diff), name), 
+                            fieldnames(trace_type)[1:end-1])
+        push!(stmts, :($trace = $(QuoteNode(trace_type))($(constructor_args...),
+                        $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref))))))
+    else
+        push!(stmts, :($static_ir_gen_fn_ref = $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref)))))
+        push!(stmts, :($trace = $(QuoteNode(trace_type))($(fieldnames(trace_type)...))))
+    end
 end
 
 function generate_discard!(stmts::Vector{Expr},
@@ -501,7 +522,7 @@ function codegen_update(trace_type::Type{T}, args_type::Type, argdiffs_type::Typ
     end
 
     ir = get_ir(gen_fn_type)
-    track_diffs = Val(get_track_diffs(gen_fn_type))
+    options = get_options(gen_fn_type)
 
     # forward marking pass
     fwd_state = ForwardPassState()
@@ -511,21 +532,25 @@ function codegen_update(trace_type::Type{T}, args_type::Type, argdiffs_type::Typ
     end
 
     # backward marking pass
+    # TODO computes which values do we need to recompute - if we cache all Julia values, then we don't need to recompute anything.
+    # TODO: we still need to extract only:
+    # - trainable parameters nodes that we need
+    # - julia node values that we need
     bwd_state = BackwardPassState()
     push!(bwd_state.marked, ir.return_node)
     for node in reverse(ir.nodes)
-        process_backward!(fwd_state, bwd_state, node)
+        process_backward!(fwd_state, bwd_state, node, options)
     end
 
     # forward code generation pass
     stmts = Expr[]
     initialize_score_weight_num_nonempty!(stmts)
-    unpack_arguments!(stmts, ir.arg_nodes, track_diffs)
+    unpack_arguments!(stmts, ir.arg_nodes, options)
     for node in ir.nodes
-        process_codegen!(stmts, fwd_state, bwd_state, node, UpdateMode(), track_diffs)
+        process_codegen!(stmts, fwd_state, bwd_state, node, UpdateMode(), options)
     end
-    generate_return_value!(stmts, fwd_state, ir.return_node, track_diffs)
-    generate_new_trace!(stmts, trace_type, track_diffs)
+    generate_return_value!(stmts, fwd_state, ir.return_node, options)
+    generate_new_trace!(stmts, trace_type, options)
     generate_discard!(stmts, fwd_state.constrained_or_selected_choices, fwd_state.discard_calls)
 
     # return trace and weight and discard and retdiff
@@ -545,7 +570,7 @@ function codegen_regenerate(trace_type::Type{T}, args_type::Type, argdiffs_type:
     end
 
     ir = get_ir(gen_fn_type)
-    track_diffs = Val(get_track_diffs(gen_fn_type))
+    options = get_options(gen_fn_type)
 
     # forward marking pass
     fwd_state = ForwardPassState()
@@ -558,18 +583,18 @@ function codegen_regenerate(trace_type::Type{T}, args_type::Type, argdiffs_type:
     bwd_state = BackwardPassState()
     push!(bwd_state.marked, ir.return_node)
     for node in reverse(ir.nodes)
-        process_backward!(fwd_state, bwd_state, node)
+        process_backward!(fwd_state, bwd_state, node, options)
     end
 
     # forward code generation pass
     stmts = Expr[]
     initialize_score_weight_num_nonempty!(stmts)
-    unpack_arguments!(stmts, ir.arg_nodes, track_diffs)
+    unpack_arguments!(stmts, ir.arg_nodes, options)
     for node in ir.nodes
-        process_codegen!(stmts, fwd_state, bwd_state, node, RegenerateMode(), track_diffs)
+        process_codegen!(stmts, fwd_state, bwd_state, node, RegenerateMode(), options)
     end
-    generate_return_value!(stmts, fwd_state ,ir.return_node, track_diffs)
-    generate_new_trace!(stmts, trace_type, track_diffs)
+    generate_return_value!(stmts, fwd_state ,ir.return_node, options)
+    generate_new_trace!(stmts, trace_type, options)
 
     # return trace and weight and retdiff
     push!(stmts, :(return ($trace, $weight, $retdiff)))
@@ -588,7 +613,7 @@ function codegen_extend(trace_type::Type{T}, args_type::Type, argdiffs_type::Typ
     end
 
     ir = get_ir(gen_fn_type)
-    track_diffs = Val(get_track_diffs(gen_fn_type))
+    options = get_options(gen_fn_type)
 
     # forward marking pass
     fwd_state = ForwardPassState()
@@ -601,18 +626,18 @@ function codegen_extend(trace_type::Type{T}, args_type::Type, argdiffs_type::Typ
     bwd_state = BackwardPassState()
     push!(bwd_state.marked, ir.return_node)
     for node in reverse(ir.nodes)
-        process_backward!(fwd_state, bwd_state, node)
+        process_backward!(fwd_state, bwd_state, node, options)
     end
 
     # forward code generation pass
     stmts = Expr[]
     initialize_score_weight_num_nonempty!(stmts)
-    unpack_arguments!(stmts, ir.arg_nodes, track_diffs)
+    unpack_arguments!(stmts, ir.arg_nodes, options)
     for node in ir.nodes
-        process_codegen!(stmts, fwd_state, bwd_state, node, ExtendMode(), track_diffs)
+        process_codegen!(stmts, fwd_state, bwd_state, node, ExtendMode(), options)
     end
-    generate_return_value!(stmts, fwd_state, ir.return_node, track_diffs)
-    generate_new_trace!(stmts, trace_type, track_diffs)
+    generate_return_value!(stmts, fwd_state, ir.return_node, options)
+    generate_new_trace!(stmts, trace_type, options)
 
     # return trace and weight and retdiff
     push!(stmts, :(return ($trace, $weight, $retdiff)))

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -292,21 +292,38 @@ at2 = at.kernel
 end
 
 
-@testset "traced diff annotation" begin
+@testset "tracked diff annotation" begin
 
 @gen (static, diffs) function bar(x)
     return x
 end
 
-@test Gen.get_track_diffs(typeof(bar))
+@test Gen.get_options(typeof(bar)).track_diffs
 
 @gen (static) function bar(x)
     return x
 end
 
-@test !Gen.get_track_diffs(typeof(bar))
+@test !Gen.get_options(typeof(bar)).track_diffs
 
 end
+
+@testset "no julia cache annotation" begin
+
+@gen (static, nojuliacache) function bar(x)
+    return x
+end
+
+@test !Gen.get_options(typeof(bar)).cache_julia_nodes
+
+@gen (static) function bar(x)
+    return x
+end
+
+@test Gen.get_options(typeof(bar)).cache_julia_nodes
+
+end
+
 
 
 @testset "trainable parameters" begin


### PR DESCRIPTION
Add back caching of return values of Julia expressions in static IR generative functions, but make it optional.