### PR TITLE
Vectorized `Gen.normal` distribution

### DIFF
--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -75,7 +75,7 @@ function logpdf_grad(::Normal,
     diff = mu - x
     deriv_x = diff .* precision
     deriv_mu = -deriv_x
-    deriv_std = -1.0 ./ std + (diff .* diff) / (std .* std .* std)
+    deriv_std = -1.0 ./ std + (diff .* diff) ./ (std .* std .* std)
     (deriv_x, deriv_mu, deriv_std)
 end
 

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -71,7 +71,7 @@ function logpdf_grad(::Normal,
                      mu::Array{U, N},
                      std::Array{V, N}) where {T<:Real, U<:Real, V<:Real, N}
     broadcast_compatible_or_crash(x, mu, std)
-    precision = 1.0 / (std .* std)
+    precision = 1.0 ./ (std .* std)
     diff = mu - x
     deriv_x = diff .* precision
     deriv_mu = -deriv_x

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -1,9 +1,43 @@
 struct Normal <: Distribution{Float64} end
 
+function broadcast_compatible_or_crash(args...)
+    # This expression produces a DimensionMismatch exception if the shapes are
+    # incompatible.  There seems to currently be no ready-made exception-free
+    # way to check this, and I think it makes more sense to wait until that
+    # capability exists in Julia proper than to re-implement it here.
+    s = Base.Broadcast.broadcast_shape(map(size, args)...)
+    true
+end
+
+
 """
     normal(mu::Real, std::Real)
 
 Samples a `Float64` value from a normal distribution.
+
+    normal(mu::Array{Real, N}, std::Array{Real, N})
+
+Samples an `Array{Float64, N}` where each element is independently normally
+distributed.  This is equivalent to a multivariate normal with diagonal
+covariance matrix, but its implementation is more efficient than that of the
+more general `mvnormal` for this case.
+
+The shapes of `mu` and `std` must be broadcast-compatible.  For methods such as
+`logpdf(x, mu, std)` which involve an element of the support of the
+distribution, the shapes of `x`, `mu` and `std` must be mutually
+broadcast-compatible.
+
+If `N == 0`, then distribution-related methods such as `logpdf`, `logpdf_grad`
+and `random` return `Float64`s rather than properly returning `Array{Float64,
+0}`s.  This is consistent with Julia's own inconsistency on the matter:
+
+```jldoctest
+julia> typeof(ones())
+Array{Float64,0}
+
+julia> typeof(ones() .* ones())
+Float64
+```
 """
 const normal = Normal()
 
@@ -11,6 +45,14 @@ function logpdf(::Normal, x::Real, mu::Real, std::Real)
     var = std * std
     diff = x - mu
     -(diff * diff)/ (2.0 * var) - 0.5 * log(2.0 * pi * var)
+end
+
+function logpdf(::Normal, x::Array{Real, N},
+                mu::Array{Real, N}, std::Array{Real, N}) where N
+    broadcast_compatible_or_crash(x, mu, std)
+    var = std .* std
+    diff = x - y
+    sum(-(diff .* diff) ./ (2.0 * var) - 0.5 * log.(2.0 * pi * var))
 end
 
 function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
@@ -22,7 +64,22 @@ function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
     (deriv_x, deriv_mu, deriv_std)
 end
 
+function logpdf_grad(::Normal, x::Array{Real, N},
+                     mu::Array{Real, N}, std::Array{Real, N}) where N
+    broadcast_compatible_or_crash(x, mu, std)
+    precision = 1.0 / (std .* std)
+    diff = mu - x
+    deriv_x = diff .* precision
+    deriv_mu = -deriv_x
+    deriv_std = -1.0 ./ std + (diff .* diff) / (std .* std .* std)
+    (deriv_x, deriv_mu, deriv_std)
+end
+
 random(::Normal, mu::Real, std::Real) = mu + std * randn()
+function random(::Normal, mu::Array{Real, N}, std::Array{Real, N}) where N
+    broadcast_compatible_or_crash(mu, std)
+    mu + std .* randn(size(mu))
+end
 
 (::Normal)(mu, std) = random(Normal(), mu, std)
 

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -6,7 +6,6 @@ function broadcast_compatible_or_crash(args...)
     # way to check this, and I think it makes more sense to wait until that
     # capability exists in Julia proper than to re-implement it here.
     s = Base.Broadcast.broadcast_shape(map(size, args)...)
-    true
 end
 
 
@@ -15,12 +14,12 @@ end
 
 Samples a `Float64` value from a normal distribution.
 
-    normal(mu::Array{Real, N}, std::Array{Real, N})
+    normal(mu::Array{T}, std::Array{U}) where {T<:Real, U<:Real}
 
-Samples an `Array{Float64, N}` where each element is independently normally
-distributed.  This is equivalent to a multivariate normal with diagonal
-covariance matrix, but its implementation is more efficient than that of the
-more general `mvnormal` for this case.
+Samples an `Array{Float64}` of shape `broadcast(size(mu), size(std))` where each
+element is independently normally distributed.  This is equivalent to a
+multivariate normal with diagonal covariance matrix, but its implementation is
+more efficient than that of the more general `mvnormal` for this case.
 
 The shapes of `mu` and `std` must be broadcast-compatible.  For methods such as
 `logpdf(x, mu, std)` which involve an element of the support of the
@@ -41,20 +40,33 @@ Float64
 """
 const normal = Normal()
 
+function logpdf(::Normal,
+                x::Union{Array{T}, T},
+                mu::Union{Array{U}, U},
+                std::Union{Array{V}, V}) where {T<:Real, U<:Real, V<:Real}
+    broadcast_compatible_or_crash(x, mu, std)
+    var = std .* std
+    diff = x .- mu
+    -(diff .* diff) ./ (2.0 * var) .- 0.5 * log.(2.0 * pi * var)
+end
+
 function logpdf(::Normal, x::Real, mu::Real, std::Real)
     var = std * std
     diff = x - mu
     -(diff * diff)/ (2.0 * var) - 0.5 * log(2.0 * pi * var)
 end
 
-function logpdf(::Normal,
-                x::Array{T, N},
-                mu::Array{U, N},
-                std::Array{V, N}) where {T<:Real, U<:Real, V<:Real, N}
+function logpdf_grad(::Normal,
+                     x::Union{Array{T}, T},
+                     mu::Union{Array{U}, U},
+                     std::Union{Array{V}, V}) where {T<:Real, U<:Real, V<:Real}
     broadcast_compatible_or_crash(x, mu, std)
-    var = std .* std
-    diff = x - y
-    sum(-(diff .* diff) ./ (2.0 * var) - 0.5 * log.(2.0 * pi * var))
+    precision = 1.0 ./ (std .* std)
+    diff = mu .- x
+    deriv_x = diff .* precision
+    deriv_mu = -deriv_x
+    deriv_std = -1.0 ./ std .+ (diff .* diff) ./ (std .* std .* std)
+    (deriv_x, deriv_mu, deriv_std)
 end
 
 function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
@@ -66,27 +78,14 @@ function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
     (deriv_x, deriv_mu, deriv_std)
 end
 
-function logpdf_grad(::Normal,
-                     x::Array{T, N},
-                     mu::Array{U, N},
-                     std::Array{V, N}) where {T<:Real, U<:Real, V<:Real, N}
-    broadcast_compatible_or_crash(x, mu, std)
-    precision = 1.0 ./ (std .* std)
-    diff = mu - x
-    deriv_x = diff .* precision
-    deriv_mu = -deriv_x
-    deriv_std = -1.0 ./ std + (diff .* diff) ./ (std .* std .* std)
-    (deriv_x, deriv_mu, deriv_std)
+function random(::Normal,
+                mu::Union{Array{T}, T},
+                std::Union{Array{U}, U}) where {T<:Real, U<:Real}
+    broadcast_shape = broadcast_compatible_or_crash(mu, std)
+    mu .+ std .* randn(broadcast_shape)
 end
 
 random(::Normal, mu::Real, std::Real) = mu + std * randn()
-
-function random(::Normal,
-                mu::Array{T, N},
-                std::Array{U, N}) where {T<:Real, U<:Real, N}
-    broadcast_compatible_or_crash(mu, std)
-    mu + std .* randn(size(mu))
-end
 
 (::Normal)(mu, std) = random(Normal(), mu, std)
 

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -25,7 +25,7 @@ The shapes of `mu` and `std` must be broadcast-compatible.  For methods such as
 `logpdf(x, mu, std)` which involve an element of the support of the
 distribution, the shapes of `x`, `mu` and `std` must be mutually
 broadcast-compatible, and the (scalar-valued) logpdf is computed as if for a
-multivariate normal of shape `broadcast(shape(x), shape(mu), shape(std))`.
+multivariate normal of shape `broadcast(size(x), size(mu), size(std))`.
 
 If all args are 0-dimensional arrays, then sampling via `random` returns a
 `Float64` rather than properly returning an `Array{Float64, 0}`s.  This is

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -47,8 +47,10 @@ function logpdf(::Normal, x::Real, mu::Real, std::Real)
     -(diff * diff)/ (2.0 * var) - 0.5 * log(2.0 * pi * var)
 end
 
-function logpdf(::Normal, x::Array{Real, N},
-                mu::Array{Real, N}, std::Array{Real, N}) where N
+function logpdf(::Normal,
+                x::Array{T, N},
+                mu::Array{U, N},
+                std::Array{V, N}) where {T<:Real, U<:Real, V<:Real, N}
     broadcast_compatible_or_crash(x, mu, std)
     var = std .* std
     diff = x - y
@@ -64,8 +66,10 @@ function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
     (deriv_x, deriv_mu, deriv_std)
 end
 
-function logpdf_grad(::Normal, x::Array{Real, N},
-                     mu::Array{Real, N}, std::Array{Real, N}) where N
+function logpdf_grad(::Normal,
+                     x::Array{T, N},
+                     mu::Array{U, N},
+                     std::Array{V, N}) where {T<:Real, U<:Real, V<:Real, N}
     broadcast_compatible_or_crash(x, mu, std)
     precision = 1.0 / (std .* std)
     diff = mu - x
@@ -76,7 +80,10 @@ function logpdf_grad(::Normal, x::Array{Real, N},
 end
 
 random(::Normal, mu::Real, std::Real) = mu + std * randn()
-function random(::Normal, mu::Array{Real, N}, std::Array{Real, N}) where N
+
+function random(::Normal,
+                mu::Array{T, N},
+                std::Array{U, N}) where {T<:Real, U<:Real, N}
     broadcast_compatible_or_crash(mu, std)
     mu + std .* randn(size(mu))
 end

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -26,9 +26,10 @@ The shapes of `mu` and `std` must be broadcast-compatible.  For methods such as
 distribution, the shapes of `x`, `mu` and `std` must be mutually
 broadcast-compatible.
 
-If `N == 0`, then distribution-related methods such as `logpdf`, `logpdf_grad`
-and `random` return `Float64`s rather than properly returning `Array{Float64,
-0}`s.  This is consistent with Julia's own inconsistency on the matter:
+If all args are 0-dimensional arrays, then distribution-related methods such as
+`logpdf`, `logpdf_grad` and `random` return `Float64`s rather than properly
+returning `Array{Float64, 0}`s.  This is consistent with Julia's own
+inconsistency on the matter:
 
 ```jldoctest
 julia> typeof(ones())

--- a/src/modeling_library/normal.jl
+++ b/src/modeling_library/normal.jl
@@ -25,7 +25,8 @@ The shapes of `mu` and `std` must be broadcast-compatible.  For methods such as
 `logpdf(x, mu, std)` which involve an element of the support of the
 distribution, the shapes of `x`, `mu` and `std` must be mutually
 broadcast-compatible, and the (scalar-valued) logpdf is computed as if for a
-multivariate normal of shape `broadcast(size(x), size(mu), size(std))`.
+multivariate normal of shape `Broadcast.broadcast_shape(size(x), size(mu),
+size(std))`.
 
 If all args are 0-dimensional arrays, then sampling via `random` returns a
 `Float64` rather than properly returning an `Array{Float64, 0}`s.  This is

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -74,19 +74,23 @@ end
     @test isapprox(actual[3], finite_diff(f, args, 3, dx))
 end
 
-@testset "zero-dimensional array normal" begin
-
-    # random
-    x = normal(0, 1)
-
-    # logpdf_grad
-    f = (x, mu, std) -> logpdf(normal, x, mu, std)
-    args = (fill(0.4), fill(0.2), fill(0.3))
-    actual = logpdf_grad(normal, args...)
-    @test isapprox(actual[1], finite_diff(f, args, 1, dx))
-    @test isapprox(actual[2], finite_diff(f, args, 2, dx))
-    @test isapprox(actual[3], finite_diff(f, args, 3, dx))
-end
+## TODO: Reinstate this test once
+## https://github.com/JuliaLang/julia/issues/32115
+## is resolved.
+#
+# @testset "zero-dimensional array normal" begin
+#
+#     # random
+#     x = normal(0, 1)
+#
+#     # logpdf_grad
+#     f = (x, mu, std) -> logpdf(normal, x, mu, std)
+#     args = (fill(0.4), fill(0.2), fill(0.3))
+#     actual = logpdf_grad(normal, args...)
+#     @test isapprox(actual[1], finite_diff(f, args, 1, dx))
+#     @test isapprox(actual[2], finite_diff(f, args, 2, dx))
+#     @test isapprox(actual[3], finite_diff(f, args, 3, dx))
+# end
 
 @testset "array normal" begin
 

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -139,12 +139,15 @@ end
                                                ones(2, 1), ones(1,2), ones(1,3))
 
     ## Equivalence of broadcast to operating on bigger arrays
-    compact = OrderedDict(:x => fill(0.2, (1, 3, 1)),
-                          :mu => fill(0.7, (1, 1, 4)),
-                          :std => fill(0.1, (2, 1, 1)))
-    expanded = OrderedDict(:x => fill(0.2, (2, 3, 4)),
-                           :mu => fill(0.7, (2, 3, 4)),
-                           :std => fill(0.1, (2, 3, 4)))
+    compact = OrderedDict(:x => reshape([0.2, 0.3, 0.4],
+                                        (1, 3, 1)),
+                          :mu => reshape([0.7, 0.7, 0.8, 0.6],
+                                         (1, 1, 4)),
+                          :std => reshape([0.2, 0.1],
+                                          (2, 1, 1)))
+    expanded = OrderedDict(:x => repeat(compact[:x], outer=(2, 1, 4)),
+                           :mu => repeat(compact[:mu], outer=(2, 3, 1)),
+                           :std => repeat(compact[:std], outer=(1, 3, 4)))
     @test (logpdf(normal, values(compact)...) ==
            logpdf(normal, values(expanded)...))
     @test (logpdf_grad(normal, values(compact)...) ==

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -118,8 +118,8 @@ end
 
     ## Return shape of `logpdf` and `logpdf_grad`
     @test size(logpdf(normal,
-                      ones(1, 3, 1), ones(2, 1, 1), ones(1, 1, 4))) == (2, 3, 4)
-    @test all(size(g) == (2, 3, 4)
+                      ones(1, 3, 1), ones(2, 1, 1), ones(1, 1, 4))) == ()
+    @test all(size(g) == ()
               for g in logpdf_grad(
                   normal, ones(1, 3, 1), ones(2, 1, 1), ones(1, 1, 4)))
     # `x` and `mu` are broadcast-incompatible

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -1,3 +1,5 @@
+import DataStructures: OrderedDict
+
 @testset "bernoulli" begin
     
     # random
@@ -87,9 +89,9 @@ end
 #     f = (x, mu, std) -> logpdf(normal, x, mu, std)
 #     args = (fill(0.4), fill(0.2), fill(0.3))
 #     actual = logpdf_grad(normal, args...)
-#     @test isapprox(actual[1], finite_diff(f, args, 1, dx))
-#     @test isapprox(actual[2], finite_diff(f, args, 2, dx))
-#     @test isapprox(actual[3], finite_diff(f, args, 3, dx))
+#     @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
+#     @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
+#     @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
 # end
 
 @testset "array normal" begin
@@ -99,16 +101,16 @@ end
 
     # logpdf_grad
     f = (x, mu, std) -> logpdf(normal, x, mu, std)
-    args = ([ 1     2     3    ;
-              4     5     6    ],
-            [ 0.1   0.2   0.3  ;
+    args = ([ 0.1   0.2   0.3  ;
               0.4   0.5   0.6  ],
             [ 0.01  0.02  0.03 ;
-              0.04  0.05  0.06 ])
+              0.04  0.05  0.06 ],
+            [ 1.    2.    3.   ;
+              4.    5.    6.   ])
     actual = logpdf_grad(normal, args...)
-    @test isapprox(actual[1], finite_diff(f, args, 1, dx))
-    @test isapprox(actual[2], finite_diff(f, args, 2, dx))
-    @test isapprox(actual[3], finite_diff(f, args, 3, dx))
+    @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
+    @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
+    @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
 end
 
 @testset "array normal with broadcasting" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -76,23 +76,19 @@ end
     @test isapprox(actual[3], finite_diff(f, args, 3, dx))
 end
 
-## TODO: Reinstate this test once
-## https://github.com/JuliaLang/julia/issues/32115
-## is resolved.
-#
-# @testset "zero-dimensional array normal" begin
-#
-#     # random
-#     x = normal(0, 1)
-#
-#     # logpdf_grad
-#     f = (x, mu, std) -> logpdf(normal, x, mu, std)
-#     args = (fill(0.4), fill(0.2), fill(0.3))
-#     actual = logpdf_grad(normal, args...)
-#     @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
-#     @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
-#     @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
-# end
+@testset "zero-dimensional array normal" begin
+
+    # random
+    x = normal(0, 1)
+
+    # logpdf_grad
+    f = (x, mu, std) -> logpdf(normal, x, mu, std)
+    args = (fill(0.4), fill(0.2), fill(0.3))
+    actual = logpdf_grad(normal, args...)
+    @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
+    @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
+    @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
+end
 
 @testset "array normal" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,31 @@ using Gen
 using Test
 import Random
 
-function finite_diff(f::Function, args::Tuple, i::Int, dx::Float64)
+"""
+Compute a numerical partial derivative of `f` with respect to the `i`th
+argument using finite differences.
+
+If `broadcast` is `false`, then `args[i]` must be a scalar.
+
+If `broadcast` is `true`, then `args[i]` may be an array.  In that case, `f` is
+assumed to be the broadcast of a function whose `i`th argument is a scalar.  In
+particular, `f` must still operate independently on each element of `i`.  This
+condition cannot be checked automatically for arbitrary `f::Function`, so the
+caller must guarantee it.
+"""
+function finite_diff(f::Function, args::Tuple, i::Int, dx::Float64;
+                     broadcast=false)
     pos_args = Any[args...]
-    pos_args[i] += dx
     neg_args = Any[args...]
-    neg_args[i] -= dx
-    return (f(pos_args...) - f(neg_args...)) / (2. * dx)
+    if broadcast
+        pos_args[i] = copy(args[i]) .+ dx
+        neg_args[i] = copy(args[i]) .- dx
+        return (f(pos_args...) - f(neg_args...)) ./ (2. * dx)
+    else
+        pos_args[i] += dx
+        neg_args[i] -= dx
+        return (f(pos_args...) - f(neg_args...)) / (2. * dx)
+    end
 end
 
 function finite_diff_vec(f::Function, args::Tuple, i::Int, j::Int, dx::Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,9 +10,9 @@ If `broadcast` is `false`, then `args[i]` must be a scalar.
 
 If `broadcast` is `true`, then `args[i]` may be an array.  In that case, `f` is
 assumed to be the broadcast of a function whose `i`th argument is a scalar.  In
-particular, `f` must still operate independently on each element of `i`.  This
-condition cannot be checked automatically for arbitrary `f::Function`, so the
-caller must guarantee it.
+particular, `f` must still operate independently on each element of `args[i]`.
+This condition cannot be checked automatically for arbitrary `f::Function`, so
+the caller must guarantee it.
 """
 function finite_diff(f::Function, args::Tuple, i::Int, dx::Float64;
                      broadcast=false)


### PR DESCRIPTION
# Summary

This PR implements `Gen.broadcasted_normal`, which is like `Gen.normal` except that the parameters `mu` and `std` are broadcast-compatible arrays, and the samples from this distribution have shape `Broadcast.broadcast_shapes(size(mu), size(std))`.  The distribution represents a random `Array` of independent normals.  This is equivalent to (a reshape of) a multivariate normal with diagonal covariance matrix, but its implementation is more efficient than that of the more general `Gen.mvnormal`.

One common use case this distribution serves is modelling IID Gaussian noise.