### PR TITLE
Update parsing to allow returning @trace in a static DSL

### DIFF
--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -194,7 +194,7 @@ function parse_trace_line!(stmts::Vector{Expr}, bindings, line::Expr)
     end
 end
 
-# return foo (must be a symbol)
+# return foo (must be a symbol) or return @trace(..)
 function parse_return!(stmts::Vector{Expr}, bindings, line::Expr)
     if line.head != :return
         return false
@@ -202,7 +202,9 @@ function parse_return!(stmts::Vector{Expr}, bindings, line::Expr)
     if isa(line.args[1], Expr) && line.args[1].head == :macrocall
         var = gensym()
         typ = QuoteNode(Any)
-        res = parse_trace_expr!(stmts, bindings, var, line.args[1], typ)
+        if !parse_trace_expr!(stmts, bindings, var, line.args[1], typ)
+            return false # the right-hand-side is a macro but not a valid `@trace` expression
+        end
     elseif isa(line.args[1], Symbol)
         var = line.args[1]
     else

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -115,6 +115,7 @@ end
 choice_or_call_at(gen_fn::GenerativeFunction, addr_typ) = call_at(gen_fn, addr_typ)
 choice_or_call_at(dist::Distribution, addr_typ) = choice_at(dist, addr_typ)
 
+       # parse_trace_expr!(stmts::Vector{Expr}, bindings, name::Symbol("##XYZ"), line::Epr(not :(=)), typ)
 function parse_trace_expr!(stmts, bindings, name, addr_expr, typ)
     # NOTE: typ is unused
     if !(isa(addr_expr, Expr) && addr_expr.head == :macrocall
@@ -195,10 +196,18 @@ end
 
 # return foo (must be a symbol)
 function parse_return!(stmts::Vector{Expr}, bindings, line::Expr)
-    if line.head != :return || !isa(line.args[1], Symbol)
+    if line.head != :return
         return false
     end
-    var = line.args[1]
+    if isa(line.args[1], Expr) && line.args[1].head == :macrocall
+        var = gensym()
+        typ = QuoteNode(Any)
+        res = parse_trace_expr!(stmts, bindings, var, line.args[1], typ)
+    elseif isa(line.args[1], Symbol)
+        var = line.args[1]
+    else
+        return false
+    end
     if haskey(bindings, var)
         node = bindings[var]
         push!(stmts, :(set_return_node!(builder, $(esc(node)))))

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -343,6 +343,35 @@ theta = get_node_by_name(ir, :theta)
 
 end
 
+@testset "returning a trace directly" begin
+
+@gen (static) function f1()
+    x = @trace(normal(0, 1), :foo)
+    return x
+end
+
+@gen (static) function f2()
+    return @trace(normal(0, 1), :foo)
+end
+
+ir1 = Gen.get_ir(typeof(f1))
+ir2 = Gen.get_ir(typeof(f2))
+return_node1 = ir1.return_node
+return_node2 = ir2.return_node
+@test isa(return_node2, typeof(return_node1))
+@test return_node2.dist == return_node1.dist
+
+inputs1 = return_node1.inputs
+inputs2 = return_node2.inputs
+@test 0 == inputs1[1].fn() == inputs2[1].fn()
+@test 1 == inputs1[2].fn() == inputs2[2].fn()
+
+@test return_node2.name != return_node1.name
+@test return_node2.addr == return_node1.addr
+@test return_node2.typ === return_node1.typ
+
+end
+
 @testset "use of 'end'" begin
 
 @gen (static) function foo()


### PR DESCRIPTION
This PR updates how returns are parsed to allow returning a trace directly. To do this, I modified `parse_return!` to call `parse_trace_expr!` to handle the returned expression. I've tested this out with the example given in #87 and it produces comparable code. Let me know if I'm missing anything.

Closes #87