### PR TITLE
Add support for gradient ops on vector-valued choices

### DIFF
--- a/src/backprop.jl
+++ b/src/backprop.jl
@@ -17,7 +17,7 @@ increment_deriv!(arg, deriv) = ReverseDiff.increment_deriv!(arg, deriv)
 seed!(tracked) = ReverseDiff.seed!(tracked)
 unseed!(tracked) = ReverseDiff.unseed!(tracked)
 
-using ReverseDiff: InstructionTape, TrackedReal, SpecialInstruction
+using ReverseDiff: InstructionTape, TrackedReal, SpecialInstruction, TrackedArray
 
 ########
 # fill #

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -160,11 +160,28 @@ and return the number of elements in `arr` that were populated.
 """
 function to_array(choices::ChoiceMap, ::Type{T}) where {T}
     arr = Vector{T}(undef, 32)
-    n = _fill_array!(choices, arr, 0)
+    n = _fill_array!(choices, arr, 1)
     @assert n <= length(arr)
     resize!(arr, n)
     arr
 end
+
+function _fill_array!(value::T, arr::Vector{T}, start_idx::Int) where {T}
+    if length(arr) < start_idx
+        resize!(arr, 2 * start_idx)
+    end
+    arr[start_idx] = value
+    1
+end
+
+function _fill_array!(value::Vector{T}, arr::Vector{T}, start_idx::Int) where {T}
+    if length(arr) < start_idx + length(value)
+        resize!(arr, 2 * (start_idx + length(value)))
+    end
+    arr[start_idx:start_idx+length(value)-1] = value
+    length(value)
+end
+
 
 """
     choices::ChoiceMap = from_array(proto_choices::ChoiceMap, arr::Vector)
@@ -189,11 +206,20 @@ but with values read off from `arr`, starting at position `start_idx`, and the
 number of elements read from `arr`.
 """
 function from_array(proto_choices::ChoiceMap, arr::Vector)
-    (n, choices) = _from_array(proto_choices, arr, 0)
+    (n, choices) = _from_array(proto_choices, arr, 1)
     if n != length(arr)
         error("Dimension mismatch: $n, $(length(arr))")
     end
     choices
+end
+
+function _from_array(::T, arr::Vector{T}, start_idx::Int) where {T}
+    (1, arr[start_idx])
+end
+
+function _from_array(value::Vector{T}, arr::Vector{T}, start_idx::Int) where {T}
+    n_read = length(value)
+    (n_read, arr[start_idx:start_idx+n_read-1])
 end
 
 
@@ -425,52 +451,54 @@ function unpair(choices::ChoiceMap, key1::Symbol, key2::Symbol)
     (a, b)
 end
 
-# TODO make it a generated function?
+# TODO make a generated function?
 function _fill_array!(choices::StaticChoiceMap, arr::Vector{T}, start_idx::Int) where {T}
-    if length(arr) < start_idx + length(choices.leaf_nodes)
-        resize!(arr, 2 * length(arr))
+    idx = start_idx
+    for value in choices.leaf_nodes
+        n_written = _fill_array!(value, arr, idx)
+        idx += n_written
     end
-    for (i, value) in enumerate(choices.leaf_nodes)
-        arr[start_idx + i] = value
-    end
-    idx = start_idx + length(choices.leaf_nodes)
-    for (i, node) in enumerate(choices.internal_nodes)
+    for node in choices.internal_nodes
         n_written = _fill_array!(node, arr, idx)
         idx += n_written
     end
     idx - start_idx
 end
 
-@generated function _from_array(proto_choices::StaticChoiceMap{R,S,T,U}, arr::Vector{V}, start_idx::Int) where {R,S,T,U,V}
+@generated function _from_array(
+        proto_choices::StaticChoiceMap{R,S,T,U}, arr::Vector{V}, start_idx::Int) where {R,S,T,U,V}
     leaf_node_keys = proto_choices.parameters[1]
     leaf_node_types = proto_choices.parameters[2].parameters
     internal_node_keys = proto_choices.parameters[3]
     internal_node_types = proto_choices.parameters[4].parameters
 
+    exprs = [quote idx = start_idx end]
+    leaf_node_names = []
+    internal_node_names = []
+
     # leaf nodes
-    leaf_node_refs = Expr[]
-    for (i, key) in enumerate(leaf_node_keys)
-        expr = Expr(:ref, :arr, Expr(:call, :(+), :start_idx, QuoteNode(i)))
-        push!(leaf_node_refs, expr)
+    for key in leaf_node_keys
+        value = gensym()
+        push!(leaf_node_names, value)
+        push!(exprs, quote
+            (n_read, $value) = _from_array(proto_choices.leaf_nodes.$key, arr, idx)
+            idx += n_read
+        end)
     end
 
     # internal nodes
-    internal_node_blocks = Expr[]
-    internal_node_names = Symbol[]
-    for (key, typ) in zip(internal_node_keys, internal_node_types)
+    for key in internal_node_keys
         node = gensym()
         push!(internal_node_names, node)
-        push!(internal_node_blocks, quote
-            (n_read, $node::$typ) = _from_array(proto_choices.internal_nodes.$key, arr, idx)
+        push!(exprs, quote
+            (n_read, $node) = _from_array(proto_choices.internal_nodes.$key, arr, idx)
             idx += n_read 
         end)
     end
 
     quote
-        n_read = $(QuoteNode(length(leaf_node_keys)))
-        leaf_nodes_field = NamedTuple{R,S}(($(leaf_node_refs...),))
-        idx::Int = start_idx + n_read
-        $(internal_node_blocks...)
+        $(exprs...)
+        leaf_nodes_field = NamedTuple{R,S}(($(leaf_node_names...),))
         internal_nodes_field = NamedTuple{T,U}(($(internal_node_names...),))
         choices = StaticChoiceMap{R,S,T,U}(leaf_nodes_field, internal_nodes_field)
         (idx - start_idx, choices)
@@ -730,15 +758,14 @@ end
 Base.setindex!(choices::DynamicChoiceMap, value, addr) = set_value!(choices, addr, value)
 
 function _fill_array!(choices::DynamicChoiceMap, arr::Vector{T}, start_idx::Int) where {T}
-    if length(arr) < start_idx + length(choices.leaf_nodes)
-        resize!(arr, 2 * length(arr))
-    end
     leaf_keys_sorted = sort(collect(keys(choices.leaf_nodes)))
     internal_node_keys_sorted = sort(collect(keys(choices.internal_nodes)))
-    for (i, key) in enumerate(leaf_keys_sorted)
-        arr[start_idx + i] = choices.leaf_nodes[key]
+    idx = start_idx
+    for key in leaf_keys_sorted
+        value = choices.leaf_nodes[key]
+        n_written = _fill_array!(value, arr, idx)
+        idx += n_written
     end
-    idx = start_idx + length(choices.leaf_nodes)
     for key in internal_node_keys_sorted
         n_written = _fill_array!(get_submap(choices, key), arr, idx)
         idx += n_written
@@ -751,10 +778,12 @@ function _from_array(proto_choices::DynamicChoiceMap, arr::Vector{T}, start_idx:
     choices = DynamicChoiceMap()
     leaf_keys_sorted = sort(collect(keys(proto_choices.leaf_nodes)))
     internal_node_keys_sorted = sort(collect(keys(proto_choices.internal_nodes)))
-    for (i, key) in enumerate(leaf_keys_sorted)
-        choices.leaf_nodes[key] = arr[start_idx + i]
+    idx = start_idx
+    for key in leaf_keys_sorted
+        (n_read, value) = _from_array(proto_choices.leaf_nodes[key], arr, idx)
+        idx += n_read
+        choices.leaf_nodes[key] = value
     end
-    idx = start_idx + length(choices.leaf_nodes)
     for key in internal_node_keys_sorted
         (n_read, node) = _from_array(get_submap(proto_choices, key), arr, idx)
         idx += n_read

--- a/src/dynamic/backprop.jl
+++ b/src/dynamic/backprop.jl
@@ -223,7 +223,7 @@ mutable struct GFBackpropTraceState
     visitor::AddressVisitor
     params::Dict{Symbol,Any}
     selection::Selection
-    tracked_choices::Trie{Any,TrackedReal}
+    tracked_choices::Trie{Any,Union{TrackedReal,TrackedArray}}
     value_choices::DynamicChoiceMap
     gradient_choices::DynamicChoiceMap
 end
@@ -231,7 +231,7 @@ end
 function GFBackpropTraceState(trace, selection, params, tape)
     score = track(0., tape)
     visitor = AddressVisitor()
-    tracked_choices = Trie{Any,TrackedReal}()
+    tracked_choices = Trie{Any,Union{TrackedReal,TrackedArray}}()
     value_choices = choicemap()
     gradient_choices = choicemap()
     GFBackpropTraceState(trace, score, tape, visitor, params,
@@ -239,7 +239,7 @@ function GFBackpropTraceState(trace, selection, params, tape)
 end
 
 function fill_gradient_map!(gradient_choices::DynamicChoiceMap,
-                             tracked_trie::Trie{Any,TrackedReal})
+                             tracked_trie::Trie{Any,Union{TrackedReal,TrackedArray}})
     for (key, tracked) in get_leaf_nodes(tracked_trie)
         set_value!(gradient_choices, key, deriv(tracked))
     end
@@ -254,7 +254,7 @@ function fill_gradient_map!(gradient_choices::DynamicChoiceMap,
 end
 
 function fill_value_map!(value_choices::DynamicChoiceMap,
-                          tracked_trie::Trie{Any,TrackedReal})
+                          tracked_trie::Trie{Any,Union{TrackedReal,TrackedArray}})
     for (key, tracked) in get_leaf_nodes(tracked_trie)
         set_value!(value_choices, key, value(tracked))
     end

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -1,16 +1,16 @@
 @testset "static assignment to/from array" begin
-    submap = StaticChoiceMap((a=1., b=2.),NamedTuple())
+    submap = StaticChoiceMap((a=1., b=[2., 2.5]),NamedTuple())
     outer = StaticChoiceMap((c=3.,), (d=submap, e=submap))
     
     arr = to_array(outer, Float64)
-    @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 1.0, 2.0]
+    @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 2.5, 1.0, 2.0, 2.5]
     
-    choices = from_array(outer, Float64[1, 2, 3, 4, 5])
+    choices = from_array(outer, Float64[1, 2, 3, 4, 5, 6, 7])
     @test choices[:c] == 1.0
     @test choices[:d => :a] == 2.0
-    @test choices[:d => :b] == 3.0
-    @test choices[:e => :a] == 4.0
-    @test choices[:e => :b] == 5.0
+    @test choices[:d => :b] == [3.0, 4.0]
+    @test choices[:e => :a] == 5.0
+    @test choices[:e => :b] == [6.0, 7.0]
     @test length(collect(get_submaps_shallow(choices))) == 2
     @test length(collect(get_values_shallow(choices))) == 1
     submap1 = get_submap(choices, :d)
@@ -26,19 +26,19 @@ end
     set_value!(outer, :c, 3.)
     submap = choicemap()
     set_value!(submap, :a, 1.)
-    set_value!(submap, :b, 2.)
+    set_value!(submap, :b, [2., 2.5])
     set_submap!(outer, :d, submap)
     set_submap!(outer, :e, submap)
     
     arr = to_array(outer, Float64)
-    @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 1.0, 2.0]
+    @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 2.5, 1.0, 2.0, 2.5]
     
-    choices = from_array(outer, Float64[1, 2, 3, 4, 5])
+    choices = from_array(outer, Float64[1, 2, 3, 4, 5, 6, 7])
     @test choices[:c] == 1.0
     @test choices[:d => :a] == 2.0
-    @test choices[:d => :b] == 3.0
-    @test choices[:e => :a] == 4.0
-    @test choices[:e => :b] == 5.0
+    @test choices[:d => :b] == [3.0, 4.0]
+    @test choices[:e => :a] == 5.0
+    @test choices[:e => :b] == [6.0, 7.0]
     @test length(collect(get_submaps_shallow(choices))) == 2
     @test length(collect(get_values_shallow(choices))) == 1
     submap1 = get_submap(choices, :d)


### PR DESCRIPTION
Strengthens support for gradient operations on vector-valued random choices.

In particular, previously only choice maps containing real-valued random choices supported conversion to/from flat floating point arrays (which is used in inference operations like `hmc`, `mala`, `map_optimize`, etc.). Now real vector-valued random choices are supported too.

Addresses https://github.com/probcomp/Gen/issues/8.