### PR TITLE
MultivariateNormal logpdf gradients w.r.t mean and covariance

### DIFF
--- a/src/modeling_library/mvnormal.jl
+++ b/src/modeling_library/mvnormal.jl
@@ -16,8 +16,13 @@ end
 function logpdf_grad(::MultivariateNormal, x::AbstractVector{T}, mu::AbstractVector{U},
                 cov::AbstractMatrix{V}) where {T,U,V}
     dist = Distributions.MvNormal(mu, cov)
+    inv_cov = Distributions.invcov(dist)
+
     x_deriv = Distributions.gradlogpdf(dist, x)
-    (x_deriv, nothing, nothing)
+    mu_deriv = -x_deriv
+    cov_deriv = -0.5 * (inv_cov - (mu_deriv * transpose(mu_deriv)))
+
+    (x_deriv, mu_deriv, cov_deriv)
 end
 
 function random(::MultivariateNormal, mu::AbstractVector{U},
@@ -28,6 +33,6 @@ end
 (::MultivariateNormal)(mu, cov) = random(MultivariateNormal(), mu, cov)
 
 has_output_grad(::MultivariateNormal) = true
-has_argument_grads(::MultivariateNormal) = (false, false)
+has_argument_grads(::MultivariateNormal) = (true, true)
 
 export mvnormal

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -172,8 +172,8 @@ end
     @test isapprox(actual[1][2], finite_diff_vec(f, args, 1, 2, dx))
     @test isapprox(actual[2][1], finite_diff_vec(f, args, 2, 1, dx))
     @test isapprox(actual[2][2], finite_diff_vec(f, args, 2, 2, dx))
-
-    @test actual[3] === nothing # not yet implemented
+    @test isapprox(actual[3][1, 1], finite_diff_mat_sym(f, args, 3, 1, 1, dx))
+    @test isapprox(actual[3][1, 2], finite_diff_mat_sym(f, args, 3, 1, 2, dx))
 end
 
 @testset "piecewise_uniform" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -174,6 +174,8 @@ end
     @test isapprox(actual[2][2], finite_diff_vec(f, args, 2, 2, dx))
     @test isapprox(actual[3][1, 1], finite_diff_mat_sym(f, args, 3, 1, 1, dx))
     @test isapprox(actual[3][1, 2], finite_diff_mat_sym(f, args, 3, 1, 2, dx))
+    @test isapprox(actual[3][2, 1], finite_diff_mat_sym(f, args, 3, 2, 1, dx))
+    @test isapprox(actual[3][2, 2], finite_diff_mat_sym(f, args, 3, 2, 2, dx))
 end
 
 @testset "piecewise_uniform" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -170,7 +170,9 @@ end
     actual = logpdf_grad(mvnormal, args...)
     @test isapprox(actual[1][1], finite_diff_vec(f, args, 1, 1, dx))
     @test isapprox(actual[1][2], finite_diff_vec(f, args, 1, 2, dx))
-    @test actual[2] === nothing # not yet implemented 
+    @test isapprox(actual[2][1], finite_diff_vec(f, args, 2, 1, dx))
+    @test isapprox(actual[2][2], finite_diff_vec(f, args, 2, 2, dx))
+
     @test actual[3] === nothing # not yet implemented
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,31 @@ function finite_diff_vec(f::Function, args::Tuple, i::Int, j::Int, dx::Float64)
     return (f(pos_args...) - f(neg_args...)) / (2. * dx)
 end
 
+"""
+Compute a numerical partial derivative of `f` with respect to the `i`th argument, a symettric matrix, using finite differences.
+
+Finite differences are applied symettrically to off-diagonal elements of the matrix, ensuring that the modified matrix is still symettric. 
+
+When applied to off-diagonal elements, the finite difference is scaled by a factor of 1/2.
+
+The condition that the `i`th argument is a symettric matrix cannot be checked automatically, so the caller must guarantee it.
+"""
+
+function finite_diff_mat_sym(f::Function, args::Tuple, i::Int, j::Int, k::Int, dx::Float64)
+    pos_args = Any[deepcopy(args)...]
+    pos_args[i][j, k] += dx
+    neg_args = Any[deepcopy(args)...]
+    neg_args[i][j, k] -= dx
+    
+    if j!=k
+        pos_args[i][k, j] += dx
+        neg_args[i][k, j] -= dx
+        return (f(pos_args...) - f(neg_args...)) / (4. * dx)
+    end
+    
+    return (f(pos_args...) - f(neg_args...)) / (2. * dx)
+end
+
 const dx = 1e-6
 
 include("autodiff.jl")


### PR DESCRIPTION
This pull request implements gradients of the multivariate normal distribution's log likelihood with respect to its mean vector and covariance matrix. This enables gradient-based inference in models where a MultivariateNormal's mean vector or covariance matrix is a function of some latent random variable, e.g. Gaussian Process Latent Variable Models.