### PR TITLE
Implement `ChoiceMapNestedView`

### DIFF
--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -327,3 +327,11 @@ end
     @test c != a
 
 end
+
+@testset "choice map nested view" begin
+    c = choicemap((:a, 1),
+                  (:b => :c, 2))
+    cv = nested_view(c)
+    @test c[:a] == cv[:a]
+    @test c[:b => :c] == cv[:b][:c]
+end


### PR DESCRIPTION
Addresses https://github.com/probcomp/Gen/issues/156.  As mentioned there, in the longer term we may want to change the underlying implementation of choice maps to look more like this under the hood, but for now we can just use a simple wrapper.

Example usage:
```julia
using Gen
c = choicemap((:a, 1),
              (:b => :c, 2))
cv = nested_view(c)
@assert c[:a] == cv[:a]
@assert c[:b => :c] == cv[:b][:c]
```