### PR TITLE
Fix potential name collision in generated code

### DIFF
--- a/src/static_ir/update.jl
+++ b/src/static_ir/update.jl
@@ -555,16 +555,18 @@ function codegen_regenerate(trace_type::Type{T}, args_type::Type, argdiffs_type:
     Expr(:block, stmts...)
 end
 
-push!(generated_functions, quote
-@generated function $(Expr(:(.), Gen, QuoteNode(:update)))(trace::T, args::Tuple, argdiffs::Tuple,
-                               constraints::$(QuoteNode(ChoiceMap))) where {T<:$(QuoteNode(StaticIRTrace))}
-    $(QuoteNode(codegen_update))(trace, args, argdiffs, constraints)
-end
-end)
+let T = gensym()
+    push!(generated_functions, quote
+    @generated function $(Expr(:(.), Gen, QuoteNode(:update)))(trace::$T, args::Tuple, argdiffs::Tuple,
+                                   constraints::$(QuoteNode(ChoiceMap))) where {$T<:$(QuoteNode(StaticIRTrace))}
+        $(QuoteNode(codegen_update))(trace, args, argdiffs, constraints)
+    end
+    end)
 
-push!(generated_functions, quote
-@generated function $(Expr(:(.), Gen, QuoteNode(:regenerate)))(trace::T, args::Tuple, argdiffs::Tuple,
-                                   selection::$(QuoteNode(Selection))) where {T<:$(QuoteNode(StaticIRTrace))}
-    $(QuoteNode(codegen_regenerate))(trace, args, argdiffs, selection)
+    push!(generated_functions, quote
+    @generated function $(Expr(:(.), Gen, QuoteNode(:regenerate)))(trace::$T, args::Tuple, argdiffs::Tuple,
+                                       selection::$(QuoteNode(Selection))) where {$T<:$(QuoteNode(StaticIRTrace))}
+        $(QuoteNode(codegen_regenerate))(trace, args, argdiffs, selection)
+    end
+    end)
 end
-end)

--- a/test/static_ir/static_ir.jl
+++ b/test/static_ir/static_ir.jl
@@ -563,7 +563,7 @@ end
     load_generated_functions()
     selection = StaticSelection(select(:mean))
     (tr, _) = generate(model, (1,))
-    # At the time the issue was filed, this line produceda crash
+    # At the time the issue was filed, this line produced a crash
     (tr, ) = mh(tr, selection)
 end
 

--- a/test/static_ir/static_ir.jl
+++ b/test/static_ir/static_ir.jl
@@ -554,4 +554,17 @@ Gen.load_generated_functions()
     @test counter == 1
 end
 
+@testset "regression test for https://github.com/probcomp/Gen/issues/168" begin
+    @gen (static) function model(var)
+        mean = @trace(normal(0, 1), :mean)
+        T = @trace(normal(mean, var), :T)
+        return T
+    end
+    load_generated_functions()
+    selection = StaticSelection(select(:mean))
+    (tr, _) = generate(model, (1,))
+    # At the time the issue was filed, this line produceda crash
+    (tr, ) = mh(tr, selection)
+end
+
 end # @testset "static IR"


### PR DESCRIPTION
Fixes https://github.com/probcomp/Gen/issues/168.

Adds a regression test (pasting @SamWitty's [minimal example](https://github.com/probcomp/Gen/issues/168#issue-536032234)) that failed before the fix.