### PR TITLE
auxiliary state accessing for static dsl

### DIFF
--- a/src/modeling_library/call_at/call_at.jl
+++ b/src/modeling_library/call_at/call_at.jl
@@ -27,6 +27,22 @@ struct CallAtTrace <: Trace
     key::Any
 end
 
+function Base.getindex(trace::CallAtTrace, addr::Pair)
+    first, rest = addr
+    if first == trace.key
+        return trace.subtrace[rest]
+    else
+        error("Address prefix $addr not found.")
+    end
+end
+function Base.getindex(trace::CallAtTrace, addr)
+    if addr == trace.key
+        return trace.subtrace[]
+    else
+        error("Address $addr not found.")
+    end
+end
+
 get_args(trace::CallAtTrace) = (get_args(trace.subtrace)..., trace.key)
 get_retval(trace::CallAtTrace) = get_retval(trace.subtrace)
 get_score(trace::CallAtTrace) = get_score(trace.subtrace)


### PR DESCRIPTION
I’ve implemented the auxiliary trace accessing for the static DSL, according to the functionality specified in #153.  I copied over the functionality tests from #153 as well; everything appears to be passing.

A couple little “hygiene” decisions arose when doing this.   For the aux state to be accessible, we need to add a `get_subtrace` method and a `getindex` method; I’ve written the code so that these are accessible via `Gen.static_get_subtrace` and `Gen.static_getindex`.  I followed the Juliaism used throughout the static trace code to use `Val` objects for multiple dispatch for the new generated functions I wrote, so these take `Val`-wrapped addresses as inputs.

Currently, I am making these functions easily accessible in the Gen namespace.  Alternatively, we could use `gensym()` to create a random identifier for `static_get_subtrace` and `static_getindex`, or we could rename to `_static_get_subtrace` and `_static_getindex` to denote that they aren’t intended to be outward-facing.  My inclination was to use `gensym`, but I saw that the `static_get_submap` functions, etc., are made accessible as part of the Gen namespace, so tried to follow suit with this.  Let me know what you think would be better.

Also, as was noted in an earlier discussion, it feels a bit like implementing the choicemap code separately from the `getindex(trace, …)` code is a little bit redundant.  Not that hard to do separately so probably not a big deal, but if we think of a more elegant implementation, that would be nice.

And of course, let me know if anything looks off in the code, or there’s anything that can be improved.  Happy holidays!