### PR TITLE
20200107 georgematheos fast static lookup

### DIFF
--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -69,24 +69,24 @@ function Base.isempty(::ChoiceMap)
     true
 end
 
-get_submap(choices::ChoiceMap, addr) = EmptyChoiceMap()
-has_value(choices::ChoiceMap, addr) = false
-get_value(choices::ChoiceMap, addr) = throw(KeyError(addr))
-Base.getindex(choices::ChoiceMap, addr) = get_value(choices, addr)
+@inline get_submap(choices::ChoiceMap, addr) = EmptyChoiceMap()
+@inline has_value(choices::ChoiceMap, addr) = false
+@inline get_value(choices::ChoiceMap, addr) = throw(KeyError(addr))
+@inline Base.getindex(choices::ChoiceMap, addr) = get_value(choices, addr)
 
-function _has_value(choices::T, addr::Pair) where {T <: ChoiceMap}
+@inline function _has_value(choices::T, addr::Pair) where {T <: ChoiceMap}
     (first, rest) = addr
     submap = get_submap(choices, first)
     has_value(submap, rest)
 end
 
-function _get_value(choices::T, addr::Pair) where {T <: ChoiceMap}
+@inline function _get_value(choices::T, addr::Pair) where {T <: ChoiceMap}
     (first, rest) = addr
     submap = get_submap(choices, first)
     get_value(submap, rest)
 end
 
-function _get_submap(choices::T, addr::Pair) where {T <: ChoiceMap}
+@inline function _get_submap(choices::T, addr::Pair) where {T <: ChoiceMap}
     (first, rest) = addr
     submap = get_submap(choices, first)
     get_submap(submap, rest)
@@ -365,28 +365,28 @@ function get_address_schema(::Type{StaticChoiceMap{R,S,T,U}}) where {R,S,T,U}
     StaticAddressSchema(keys)
 end
 
-function Base.isempty(choices::StaticChoiceMap)
+@inline function Base.isempty(choices::StaticChoiceMap)
     choices.isempty
 end
 
 get_values_shallow(choices::StaticChoiceMap) = pairs(choices.leaf_nodes)
 get_submaps_shallow(choices::StaticChoiceMap) = pairs(choices.internal_nodes)
-has_value(choices::StaticChoiceMap, addr::Pair) = _has_value(choices, addr)
-get_value(choices::StaticChoiceMap, addr::Pair) = _get_value(choices, addr)
-get_submap(choices::StaticChoiceMap, addr::Pair) = _get_submap(choices, addr)
+@inline has_value(choices::StaticChoiceMap, addr::Pair) = _has_value(choices, addr)
+@inline get_value(choices::StaticChoiceMap, addr::Pair) = _get_value(choices, addr)
+@inline get_submap(choices::StaticChoiceMap, addr::Pair) = _get_submap(choices, addr)
 
 # NOTE: there is no static_has_value because this is known from the static
 # address schema
 
 ## has_value ##
 
-function has_value(choices::StaticChoiceMap, key::Symbol)
+@inline function has_value(choices::StaticChoiceMap, key::Symbol)
     haskey(choices.leaf_nodes, key)
 end
 
 ## get_submap ##
 
-function get_submap(choices::StaticChoiceMap, key::Symbol)
+@inline function get_submap(choices::StaticChoiceMap, key::Symbol)
     if haskey(choices.internal_nodes, key)
         choices.internal_nodes[key]
     elseif haskey(choices.leaf_nodes, key)
@@ -396,17 +396,17 @@ function get_submap(choices::StaticChoiceMap, key::Symbol)
     end
 end
 
-function static_get_submap(choices::StaticChoiceMap, ::Val{A}) where {A}
+@inline function static_get_submap(choices::StaticChoiceMap, ::Val{A}) where {A}
     choices.internal_nodes[A]
 end
 
 ## get_value ##
 
-function get_value(choices::StaticChoiceMap, key::Symbol)
+@inline function get_value(choices::StaticChoiceMap, key::Symbol)
     choices.leaf_nodes[key]
 end
 
-function static_get_value(choices::StaticChoiceMap, ::Val{A}) where {A}
+@inline function static_get_value(choices::StaticChoiceMap, ::Val{A}) where {A}
     choices.leaf_nodes[A]
 end
 

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -365,28 +365,28 @@ function get_address_schema(::Type{StaticChoiceMap{R,S,T,U}}) where {R,S,T,U}
     StaticAddressSchema(keys)
 end
 
-@inline function Base.isempty(choices::StaticChoiceMap)
+function Base.isempty(choices::StaticChoiceMap)
     choices.isempty
 end
 
 get_values_shallow(choices::StaticChoiceMap) = pairs(choices.leaf_nodes)
 get_submaps_shallow(choices::StaticChoiceMap) = pairs(choices.internal_nodes)
-@inline has_value(choices::StaticChoiceMap, addr::Pair) = _has_value(choices, addr)
-@inline get_value(choices::StaticChoiceMap, addr::Pair) = _get_value(choices, addr)
-@inline get_submap(choices::StaticChoiceMap, addr::Pair) = _get_submap(choices, addr)
+has_value(choices::StaticChoiceMap, addr::Pair) = _has_value(choices, addr)
+get_value(choices::StaticChoiceMap, addr::Pair) = _get_value(choices, addr)
+get_submap(choices::StaticChoiceMap, addr::Pair) = _get_submap(choices, addr)
 
 # NOTE: there is no static_has_value because this is known from the static
 # address schema
 
 ## has_value ##
 
-@inline function has_value(choices::StaticChoiceMap, key::Symbol)
+function has_value(choices::StaticChoiceMap, key::Symbol)
     haskey(choices.leaf_nodes, key)
 end
 
 ## get_submap ##
 
-@inline function get_submap(choices::StaticChoiceMap, key::Symbol)
+function get_submap(choices::StaticChoiceMap, key::Symbol)
     if haskey(choices.internal_nodes, key)
         choices.internal_nodes[key]
     elseif haskey(choices.leaf_nodes, key)
@@ -396,17 +396,17 @@ end
     end
 end
 
-@inline function static_get_submap(choices::StaticChoiceMap, ::Val{A}) where {A}
+function static_get_submap(choices::StaticChoiceMap, ::Val{A}) where {A}
     choices.internal_nodes[A]
 end
 
 ## get_value ##
 
-@inline function get_value(choices::StaticChoiceMap, key::Symbol)
+function get_value(choices::StaticChoiceMap, key::Symbol)
     choices.leaf_nodes[key]
 end
 
-@inline function static_get_value(choices::StaticChoiceMap, ::Val{A}) where {A}
+function static_get_value(choices::StaticChoiceMap, ::Val{A}) where {A}
     choices.leaf_nodes[A]
 end
 

--- a/src/modeling_library/call_at/call_at.jl
+++ b/src/modeling_library/call_at/call_at.jl
@@ -27,6 +27,22 @@ struct CallAtTrace <: Trace
     key::Any
 end
 
+function Base.getindex(trace::CallAtTrace, addr::Pair)
+    first, rest = addr
+    if first == trace.key
+        return trace.subtrace[rest]
+    else
+        error("Address prefix $addr not found.")
+    end
+end
+function Base.getindex(trace::CallAtTrace, addr)
+    if addr == trace.key
+        return trace.subtrace[]
+    else
+        error("Address $addr not found.")
+    end
+end
+
 get_args(trace::CallAtTrace) = (get_args(trace.subtrace)..., trace.key)
 get_retval(trace::CallAtTrace) = get_retval(trace.subtrace)
 get_score(trace::CallAtTrace) = get_score(trace.subtrace)

--- a/src/modeling_library/vector.jl
+++ b/src/modeling_library/vector.jl
@@ -44,19 +44,19 @@ end
 
 # trace API
 
-get_choices(trace::VectorTrace) = VectorTraceChoiceMap(trace)
-get_retval(trace::VectorTrace) = trace.retval
-get_args(trace::VectorTrace) = trace.args
-get_score(trace::VectorTrace) = trace.score
-get_gen_fn(trace::VectorTrace) = trace.gen_fn
+@inline get_choices(trace::VectorTrace) = VectorTraceChoiceMap(trace)
+@inline get_retval(trace::VectorTrace) = trace.retval
+@inline get_args(trace::VectorTrace) = trace.args
+@inline get_score(trace::VectorTrace) = trace.score
+@inline get_gen_fn(trace::VectorTrace) = trace.gen_fn
 
-function Base.getindex(trace::VectorTrace, addr::Pair)
+@inline function Base.getindex(trace::VectorTrace{GenFnType, T, U}, addr::Pair) where {GenFnType, T, U}
     (first, rest) = addr
     subtrace = trace.subtraces[first]
     subtrace[rest]
 end
 
-function Base.getindex(trace::VectorTrace, addr)
+@inline function Base.getindex(trace::VectorTrace, addr)
     # we expose the return values in the auxiliary state
     trace.retval[addr]
 end
@@ -71,14 +71,14 @@ function project(trace::VectorTrace, selection::Selection)
     weight
 end
 
-struct VectorTraceChoiceMap <: ChoiceMap
-    trace::VectorTrace
+struct VectorTraceChoiceMap{GenFnType, T, U} <: ChoiceMap
+    trace::VectorTrace{GenFnType, T, U}
 end
 
-Base.isempty(assignment::VectorTraceChoiceMap) = assignment.trace.num_nonempty == 0
-get_address_schema(::Type{VectorTraceChoiceMap}) = VectorAddressSchema()
+@inline Base.isempty(assignment::VectorTraceChoiceMap) = assignment.trace.num_nonempty == 0
+@inline get_address_schema(::Type{VectorTraceChoiceMap}) = VectorAddressSchema()
 
-function get_submap(choices::VectorTraceChoiceMap, addr::Int)
+@inline function get_submap(choices::VectorTraceChoiceMap, addr::Int)
     if addr <= choices.trace.len
         get_choices(choices.trace.subtraces[addr])
     else
@@ -86,14 +86,14 @@ function get_submap(choices::VectorTraceChoiceMap, addr::Int)
     end
 end
 
-function get_submaps_shallow(choices::VectorTraceChoiceMap)
+@inline function get_submaps_shallow(choices::VectorTraceChoiceMap)
     ((i, get_choices(choices.trace.subtraces[i])) for i=1:choices.trace.len)
 end
 
-get_submap(choices::VectorTraceChoiceMap, addr::Pair) = _get_submap(choices, addr)
-get_value(choices::VectorTraceChoiceMap, addr::Pair) = _get_value(choices, addr)
-has_value(choices::VectorTraceChoiceMap, addr::Pair) = _has_value(choices, addr)
-get_values_shallow(::VectorTraceChoiceMap) = ()
+@inline get_submap(choices::VectorTraceChoiceMap, addr::Pair) = _get_submap(choices, addr)
+@inline get_value(choices::VectorTraceChoiceMap, addr::Pair) = _get_value(choices, addr)
+@inline has_value(choices::VectorTraceChoiceMap, addr::Pair) = _has_value(choices, addr)
+@inline get_values_shallow(::VectorTraceChoiceMap) = ()
 
 
 ############################################

--- a/src/static_ir/trace.jl
+++ b/src/static_ir/trace.jl
@@ -8,27 +8,27 @@ end
 
 function get_schema end
 
-get_address_schema(::Type{StaticIRTraceAssmt{T}}) where {T} = get_schema(T)
+@inline get_address_schema(::Type{StaticIRTraceAssmt{T}}) where {T} = get_schema(T)
 
-Base.isempty(choices::StaticIRTraceAssmt) = isempty(choices.trace)
+@inline Base.isempty(choices::StaticIRTraceAssmt) = isempty(choices.trace)
 
-static_has_value(choices::StaticIRTraceAssmt, key) = false
+@inline static_has_value(choices::StaticIRTraceAssmt, key) = false
 
-function get_value(choices::StaticIRTraceAssmt, key::Symbol)
+@inline function get_value(choices::StaticIRTraceAssmt, key::Symbol)
     static_get_value(choices, Val(key))
 end
 
-function has_value(choices::StaticIRTraceAssmt, key::Symbol)
+@inline function has_value(choices::StaticIRTraceAssmt, key::Symbol)
     static_has_value(choices, Val(key))
 end
 
-function get_submap(choices::StaticIRTraceAssmt, key::Symbol)
+@inline function get_submap(choices::StaticIRTraceAssmt, key::Symbol)
     static_get_submap(choices, Val(key))
 end
 
-get_value(choices::StaticIRTraceAssmt, addr::Pair) = _get_value(choices, addr)
-has_value(choices::StaticIRTraceAssmt, addr::Pair) = _has_value(choices, addr)
-get_submap(choices::StaticIRTraceAssmt, addr::Pair) = _get_submap(choices, addr)
+@inline get_value(choices::StaticIRTraceAssmt, addr::Pair) = _get_value(choices, addr)
+@inline has_value(choices::StaticIRTraceAssmt, addr::Pair) = _has_value(choices, addr)
+@inline get_submap(choices::StaticIRTraceAssmt, addr::Pair) = _get_submap(choices, addr)
 
 #########################
 # trace type generation #
@@ -36,17 +36,17 @@ get_submap(choices::StaticIRTraceAssmt, addr::Pair) = _get_submap(choices, addr)
 
 abstract type StaticIRTrace <: Trace end
 
-function static_get_subtrace(trace::StaticIRTrace, addr)
+@inline function static_get_subtrace(trace::StaticIRTrace, addr)
     error("Not implemented")
 end
 
-static_haskey(trace::StaticIRTrace, ::Val) = false
-Base.haskey(trace::StaticIRTrace, key) = Gen.static_haskey(trace, Val(key))
+@inline static_haskey(trace::StaticIRTrace, ::Val) = false
+ Base.haskey(trace::StaticIRTrace, key) = Gen.static_haskey(trace, Val(key))
 
-function Base.getindex(trace::StaticIRTrace, addr)
+@inline function Base.getindex(trace::StaticIRTrace, addr)
     Gen.static_getindex(trace, Val(addr))
 end
-function Base.getindex(trace::StaticIRTrace, addr::Pair)
+@inline function Base.getindex(trace::StaticIRTrace, addr::Pair)
     first, rest = addr
     return Gen.static_get_subtrace(trace, Val(first))[rest]
 end


### PR DESCRIPTION
This should resolve issue #173 in most cases.  This is also an extension of #172 
which implements aux state accessing for the static DSL

As I mentioned in the issue, the static lookups are very slow when the value-type
method dispatch has to happen at runtime.  For flat lookups this is solved by inlining
`getindex` and other methods; if we have a nested structure where we
pass through a `Map` combinator,
we need the `Map` trace type to realize that the subtraces are all of the static
trace type, so the Julia compiler can properly propagate the value types at compile time.

To give a sense of the effect this PR has, we get 70x or greater speedup for static lookups (and a bit better even when passing through the map combinator).  For a more sophisticated and realistic
entity-mention model I am using for Gen profiling in general, I found that this led
to a 1.65x speedup for running gibbs sampling on the whole model, so the speedup
for the lookups makes a serious difference to performance for MCMC in general.

To give a sense of timing results, before the PR here is a timing output:
```
dynamic function lookup:
  0.118068 seconds (318.75 k allocations: 17.701 MiB)
static function lookup:
  6.757818 seconds (315.52 k allocations: 17.630 MiB)
dynamic function lookup passing through map combinator:
  0.483430 seconds (5.31 M allocations: 124.247 MiB, 12.71% gc time)
static function lookup passing through map combinator:
 13.821885 seconds (5.33 M allocations: 125.474 MiB, 0.43% gc time)
dynamic nested in static:
  7.354814 seconds (2.36 M allocations: 65.574 MiB)
static nested in static:
 13.350080 seconds (2.34 M allocations: 64.496 MiB)
static nested in dynamic:
  6.839463 seconds (3.31 M allocations: 78.605 MiB, 0.42% gc time)
```

After this change, the output is
```
dynamic function lookup:
  0.128471 seconds (336.30 k allocations: 18.604 MiB)
static function lookup:
  0.094528 seconds (317.89 k allocations: 17.739 MiB)
dynamic function lookup passing through map combinator:
  0.429125 seconds (5.37 M allocations: 127.137 MiB, 7.91% gc time)
static function lookup passing through map combinator:
  0.158622 seconds (3.38 M allocations: 97.197 MiB, 20.67% gc time)
dynamic nested in static:
  0.195995 seconds (2.37 M allocations: 65.986 MiB, 14.50% gc time)
static nested in static:
  0.132090 seconds (2.35 M allocations: 65.036 MiB, 22.17% gc time)
static nested in dynamic:
  7.036895 seconds (3.31 M allocations: 78.593 MiB, 0.39% gc time)
```

While I have updated the `Map` combinator I have not looked at the `Recurse` or `Unfold`
ones; I'll make an issue noting that we should make sure the type information
propagates correctly through these so we get the proper speedups, and to make sure
everything is inlined properly. For future combinators with subtraces they will also
need to propagate the type information properly.

This PR also does not implement a way to propagate the needed type information through
dynamic functions, so if a dynamic function calls a static function, it will remain
slow to lookup values from the static call through the dynamic trace.  I'm not sure
that there is a good way to do this since I don't see how the subtrace types under
a dynamic function could be known at compile time.  My sense is that almost all performance
critical code will need to avoid the dynamic DSL since it provides no way to propagate
argdiff information or utilize conditional independence, so probably it isn't the
end of the world if dynamic-then-static lookups are slow.  That said, if we want to improve
performance in this case we could implement some mechanism so that the static
trace lookups can use a normal hashmap lookup when it's parent function
is dynamic, and the method-dispatch technique in other cases (since this will
  be faster when it is possible to use).