### PR TITLE
20200129 georgematheos staticmacros

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -405,6 +405,34 @@ The functions must also satisfy the following rules:
 
 - Julia control flow constructs (e.g. `if`, `for`, `while`) cannot be used as top-level statements in the function body. Control flow should be implemented inside Julia functions that are called, generative functions that are called such as generative functions produced using [Generative Function Combinators](@ref).
 
+#### Macros in static DSL
+
+Gen includes several macros with special meanings for use within generative functions (`@trace`, `@param`, and `@grad`).
+In addition to these, user-defined macros may be used within the dynamic DSL.  The static DSL also supports user-defined macros,
+so long as they (non-recursively) `macroexpand` into code which makes the line valid under the restrictions of the
+static DSL.  Macros may be used in the static DSL in any of the following places:
+
+- An entire line may be a macro which (non-recursively) `macroexpand`s to a valid line for the static DSL.  For example:
+```julia
+@generate_line arg1 arg2
+```
+may be used if `macroexpand(__module__, :(@num(arg1, arg2)); recursive=false)` becomes a valid static DSL line.
+
+- A macro may be called USING PARENTHESES as the first argument to an `@trace` expression.
+
+So it is valid to include
+```julia
+a = @trace(@output_distribution(arg1, arg2), :addr)
+```
+
+But it is invalid to include
+
+```julia
+a = @trace(@output_distribution arg1 arg2 , :addr)
+```
+
+(The reason macros cannot be used without parentheses is that then `:addr` is parsed as part of the macro call.)
+
 ### Loading generated functions
 Before a function with a static annotation can be used, the [`load_generated_functions`](@ref) method must be called:
 ```@docs

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -53,7 +53,7 @@ end
 include("dynamic.jl")
 include("static.jl")
 
-function parse_gen_function(ast, annotations)
+function parse_gen_function(ast, annotations, __module__)
     if ast.head != :function
         error("syntax error at $ast in $(ast.head)")
     end
@@ -73,7 +73,7 @@ function parse_gen_function(ast, annotations)
     args = map(parse_arg, call_signature.args[2:end])
     static = DSL_STATIC_ANNOTATION in annotations
     if static
-        make_static_gen_function(name, args, body, return_type, annotations)
+        make_static_gen_function(name, args, body, return_type, annotations, __module__)
     else
         make_dynamic_gen_function(name, args, body, return_type, annotations)
     end
@@ -85,9 +85,9 @@ macro gen(annotations_expr, ast)
     annotations = parse_annotations(annotations_expr)
 
     # parse the function definition
-    parse_gen_function(ast, annotations)
+    parse_gen_function(ast, annotations, __module__)
 end
 
 macro gen(ast)
-    parse_gen_function(ast, Set{Symbol}())
+    parse_gen_function(ast, Set{Symbol}(), __module__)
 end

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -61,6 +61,20 @@ end
     ret = @trace(foo(mu), :x => i => :y)
 end
 
+macro generate_line()
+    # a = @trace(poisson(5), :a)
+    Expr(:(=), esc(:a), 
+    Expr(:macrocall, Symbol("@trace"), LineNumberNode(0), :(poisson(5)), QuoteNode(:a)))
+end
+
+@testset "macros" begin
+@gen (static) function get_a()
+    @generate_line
+    return a
+end
+Gen.load_generated_functions()
+end
+
 @testset "static DSL" begin
 
 function get_node_by_name(ir, name::Symbol)


### PR DESCRIPTION
For some code I'm working on (the BLOG to Gen project), it will be important to be able to use some macros in the static DSL.

For instance, I want to be able to write code like
```julia
@type T
@gen (static) function create_and_sample_Ts()
  @num T = poisson(5)
  samples = @trace(@sample(T), :samples)
  return samples
end
```
and have it macroexpand into some generative functions that do some useful stuff.

This PR adds support for using macros in a couple places in the static DSL.