### PR TITLE
Document `verbose` flag for importance sampling

### DIFF
--- a/src/inference/importance.jl
+++ b/src/inference/importance.jl
@@ -23,6 +23,7 @@ function importance_sampling(model::GenerativeFunction{T,U}, model_args::Tuple,
     traces = Vector{U}(undef, num_samples)
     log_weights = Vector{Float64}(undef, num_samples)
     for i=1:num_samples
+        verbose && println("sample: $i of $num_samples")
         (traces[i], log_weights[i]) = generate(model, model_args, observations)
     end
     log_total_weight = logsumexp(log_weights)
@@ -34,7 +35,7 @@ end
 function importance_sampling(model::GenerativeFunction{T,U}, model_args::Tuple,
                              observations::ChoiceMap,
                              proposal::GenerativeFunction, proposal_args::Tuple,
-                             num_samples::Int) where {T,U}
+                             num_samples::Int, verbose=false) where {T,U}
     traces = Vector{U}(undef, num_samples)
     log_weights = Vector{Float64}(undef, num_samples)
     for i=1:num_samples

--- a/src/inference/importance.jl
+++ b/src/inference/importance.jl
@@ -1,11 +1,11 @@
 """
     (traces, log_norm_weights, lml_est) = importance_sampling(model::GenerativeFunction,
-        model_args::Tuple, observations::ChoiceMap, num_samples::Int)
+        model_args::Tuple, observations::ChoiceMap, num_samples::Int, verbose=false)
 
     (traces, log_norm_weights, lml_est) = importance_sampling(model::GenerativeFunction,
         model_args::Tuple, observations::ChoiceMap,
         proposal::GenerativeFunction, proposal_args::Tuple,
-        num_samples::Int)
+        num_samples::Int, verbose=false)
 
 Run importance sampling, returning a vector of traces with associated log weights.
 
@@ -15,10 +15,11 @@ The observations are addresses that must be sampled by the model in the given mo
 The first variant uses the internal proposal distribution of the model.
 The second variant uses a custom proposal distribution defined by the given generative function.
 All addresses of random choices sampled by the proposal should also be sampled by the model function.
+Setting `verbose=true` prints a progress message every sample.
 """
 function importance_sampling(model::GenerativeFunction{T,U}, model_args::Tuple,
                              observations::ChoiceMap,
-                             num_samples::Int) where {T,U}
+                             num_samples::Int, verbose=false) where {T,U}
     traces = Vector{U}(undef, num_samples)
     log_weights = Vector{Float64}(undef, num_samples)
     for i=1:num_samples
@@ -37,6 +38,7 @@ function importance_sampling(model::GenerativeFunction{T,U}, model_args::Tuple,
     traces = Vector{U}(undef, num_samples)
     log_weights = Vector{Float64}(undef, num_samples)
     for i=1:num_samples
+        verbose && println("sample: $i of $num_samples")
         (proposed_choices, proposal_weight, _) = propose(proposal, proposal_args)
         constraints = merge(observations, proposed_choices)
         (traces[i], model_weight) = generate(model, model_args, constraints)

--- a/src/inference/importance.jl
+++ b/src/inference/importance.jl
@@ -50,16 +50,19 @@ end
 
 """
     (trace, lml_est) = importance_resampling(model::GenerativeFunction,
-        model_args::Tuple, observations::ChoiceMap, num_samples::Int)
+        model_args::Tuple, observations::ChoiceMap, num_samples::Int,
+        verbose=false)
 
     (traces, lml_est) = importance_resampling(model::GenerativeFunction,
         model_args::Tuple, observations::ChoiceMap,
         proposal::GenerativeFunction, proposal_args::Tuple,
-        num_samples::Int)
+        num_samples::Int, verbose=false)
 
 Run sampling importance resampling, returning a single trace.
 
 Unlike `importance_sampling`, the memory used constant in the number of samples.
+
+Setting `verbose=true` prints a progress message every sample.
 """
 function importance_resampling(model::GenerativeFunction{T,U}, model_args::Tuple,
                                observations::ChoiceMap,


### PR DESCRIPTION
Only found out about the `verbose` flag by looking through the code so thought it would be useful to document the option in case others find find it useful too.

This PR documents the `verbose` flag for `importance_resampling` and adds a similar verbose option to `importance_sampling`.