### PR TITLE
Add support for ~ syntax within `@gen` modeling DSLs

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -164,7 +164,7 @@ uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.9.10"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -249,7 +249,7 @@ uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "0.9.3"
 
 [[SuiteSparse]]
-deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[Test]]

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -66,14 +66,14 @@ end
 function desugar_tildes(expr)
     MacroTools.postwalk(expr) do e
         if MacroTools.@capture(e, {*} ~ rhs_)
-          :(@trace($rhs))
-      elseif MacroTools.@capture(e, {addr_} ~ rhs_)
-          :(@trace($rhs, $(addr)))
-      elseif MacroTools.@capture(e, lhs_ ~ rhs_)
-          addr_expr = address_from_expression(lhs)
-          :($lhs = @trace($rhs, $(addr_expr)))
+            :(@trace($rhs))
+        elseif MacroTools.@capture(e, {addr_} ~ rhs_)
+            :(@trace($rhs, $(addr)))
+        elseif MacroTools.@capture(e, lhs_ ~ rhs_)
+            addr_expr = address_from_expression(lhs)
+            :($lhs = @trace($rhs, $(addr_expr)))
         else
-          e
+            e
         end
     end
 end

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -1,3 +1,5 @@
+import MacroTools
+
 const DSL_STATIC_ANNOTATION = :static
 const DSL_ARG_GRAD_ANNOTATION = :grad
 const DSL_RET_GRAD_ANNOTATION = :grad
@@ -53,6 +55,29 @@ end
 include("dynamic.jl")
 include("static.jl")
 
+function address_from_expression(lhs)
+    if lhs isa Symbol
+        QuoteNode(lhs)
+    else
+        error("Syntax error: Only a variable or an address expression can appear on the lefthand side of a ~. Invalid left-hand side: $(lhs).")
+    end
+end
+
+function desugar_tildes(expr)
+    MacroTools.postwalk(expr) do e
+        if MacroTools.@capture(e, {*} ~ rhs_)
+          :(@trace($rhs))
+      elseif MacroTools.@capture(e, {addr_} ~ rhs_)
+          :(@trace($rhs, $(addr)))
+      elseif MacroTools.@capture(e, lhs_ ~ rhs_)
+          addr_expr = address_from_expression(lhs)
+          :($lhs = @trace($rhs, $(addr_expr)))
+        else
+          e
+        end
+    end
+end
+
 function parse_gen_function(ast, annotations)
     if ast.head != :function
         error("syntax error at $ast in $(ast.head)")
@@ -61,7 +86,7 @@ function parse_gen_function(ast, annotations)
         error("syntax error at $ast in $(ast.args)")
     end
     signature = ast.args[1]
-    body = ast.args[2]
+    body = desugar_tildes(ast.args[2])
     if signature.head == :(::)
         (call_signature, return_type) = signature.args
     elseif signature.head == :call

--- a/test/dynamic_dsl.jl
+++ b/test/dynamic_dsl.jl
@@ -63,135 +63,103 @@ end
 end
 
 @testset "update" begin
-
-    for notation in [:trace, :tilde]
-        if notation == :trace
-            @gen function bar()
-                @trace(normal(0, 1), :a)
-            end
-
-            @gen function baz()
-                @trace(normal(0, 1), :b)
-            end
-
-            @gen function foo()
-                if @trace(bernoulli(0.4), :branch)
-                    @trace(normal(0, 1), :x)
-                    @trace(bar(), :u)
-                else
-                    @trace(normal(0, 1), :y)
-                    @trace(baz(), :v)
-                end
-            end
-        else
-            @gen function bar()
-                a ~ normal(0, 1)
-            end
-
-            @gen function baz()
-                b ~ normal(0, 1)
-            end
-
-            @gen function foo()
-                if ({:branch} ~ bernoulli(0.4))
-                    x ~ normal(0, 1)
-                    u ~ bar()
-                else
-                    y ~ normal(0, 1)
-                    v ~ baz()
-                end
-            end
-        end
-
-        # get a trace which follows the first branch
-        constraints = choicemap()
-        constraints[:branch] = true
-        (trace,) = generate(foo, (), constraints)
-        x = get_choices(trace)[:x]
-        a = get_choices(trace)[:u => :a]
-
-        # force to follow the second branch
-        y = 1.123
-        b = -2.1
-        constraints = choicemap()
-        constraints[:branch] = false
-        constraints[:y] = y
-        constraints[:v => :b] = b
-        (new_trace, weight, retdiff, discard) = update(trace,
-            (), (), constraints)
-
-        # test discard
-        @test get_value(discard, :branch) == true
-        @test get_value(discard, :x) == x
-        @test get_value(discard, :u => :a) == a
-        @test length(collect(get_values_shallow(discard))) == 2
-        @test length(collect(get_submaps_shallow(discard))) == 1
-
-        # test new trace
-        new_assignment = get_choices(new_trace)
-        @test get_value(new_assignment, :branch) == false
-        @test get_value(new_assignment, :y) == y
-        @test get_value(new_assignment, :v => :b) == b
-        @test length(collect(get_values_shallow(new_assignment))) == 2
-        @test length(collect(get_submaps_shallow(new_assignment))) == 1
-
-        # test score and weight
-        prev_score = (
-            logpdf(bernoulli, true, 0.4) +
-            logpdf(normal, x, 0, 1) +
-            logpdf(normal, a, 0, 1))
-        expected_new_score = (
-            logpdf(bernoulli, false, 0.4) +
-            logpdf(normal, y, 0, 1) +
-            logpdf(normal, b, 0, 1))
-        expected_weight = expected_new_score - prev_score
-        @test isapprox(expected_new_score, get_score(new_trace))
-        @test isapprox(expected_weight, weight)
-
-        # test retdiff
-        @test retdiff === UnknownChange()
-
-        # Addresses under the :data namespace will be visited,
-        # but nothing there will be discarded.
-        if notation == :trace
-            @gen function loopy()
-                a = @trace(normal(0, 1), :a)
-                for i=1:5
-                    @trace(normal(a, 1), :data => i)
-                end
-            end
-        else
-            @gen function loopy()
-                a ~ normal(0, 1)
-                for i=1:5
-                    {:data => i} ~ normal(a, 1)
-                end
-            end
-        end
-
-        # Get an initial trace
-        constraints = choicemap()
-        constraints[:a] = 0
-        for i=1:5
-            constraints[:data => i] = 0
-        end
-        (trace,) = generate(loopy, (), constraints)
-
-        # Update a
-        constraints = choicemap()
-        constraints[:a] = 1
-        (new_trace, weight, retdiff, discard) = update(trace,
-            (), (), constraints)
-
-        # Test discard, score, weight, retdiff
-        @test get_value(discard, :a) == 0
-        prev_score = logpdf(normal, 0, 0, 1) * 6
-        expected_new_score = logpdf(normal, 1, 0, 1) + 5 * logpdf(normal, 0, 1, 1)
-        expected_weight = expected_new_score - prev_score
-        @test isapprox(expected_new_score, get_score(new_trace))
-        @test isapprox(expected_weight, weight)
-        @test retdiff === UnknownChange()
+    @gen function bar()
+        @trace(normal(0, 1), :a)
     end
+
+    @gen function baz()
+        @trace(normal(0, 1), :b)
+    end
+
+    @gen function foo()
+        if @trace(bernoulli(0.4), :branch)
+            @trace(normal(0, 1), :x)
+            @trace(bar(), :u)
+        else
+            @trace(normal(0, 1), :y)
+            @trace(baz(), :v)
+        end
+    end
+
+    # get a trace which follows the first branch
+    constraints = choicemap()
+    constraints[:branch] = true
+    (trace,) = generate(foo, (), constraints)
+    x = get_choices(trace)[:x]
+    a = get_choices(trace)[:u => :a]
+
+    # force to follow the second branch
+    y = 1.123
+    b = -2.1
+    constraints = choicemap()
+    constraints[:branch] = false
+    constraints[:y] = y
+    constraints[:v => :b] = b
+    (new_trace, weight, retdiff, discard) = update(trace,
+        (), (), constraints)
+
+    # test discard
+    @test get_value(discard, :branch) == true
+    @test get_value(discard, :x) == x
+    @test get_value(discard, :u => :a) == a
+    @test length(collect(get_values_shallow(discard))) == 2
+    @test length(collect(get_submaps_shallow(discard))) == 1
+
+    # test new trace
+    new_assignment = get_choices(new_trace)
+    @test get_value(new_assignment, :branch) == false
+    @test get_value(new_assignment, :y) == y
+    @test get_value(new_assignment, :v => :b) == b
+    @test length(collect(get_values_shallow(new_assignment))) == 2
+    @test length(collect(get_submaps_shallow(new_assignment))) == 1
+
+    # test score and weight
+    prev_score = (
+        logpdf(bernoulli, true, 0.4) +
+        logpdf(normal, x, 0, 1) +
+        logpdf(normal, a, 0, 1))
+    expected_new_score = (
+        logpdf(bernoulli, false, 0.4) +
+        logpdf(normal, y, 0, 1) +
+        logpdf(normal, b, 0, 1))
+    expected_weight = expected_new_score - prev_score
+    @test isapprox(expected_new_score, get_score(new_trace))
+    @test isapprox(expected_weight, weight)
+
+    # test retdiff
+    @test retdiff === UnknownChange()
+
+    # Addresses under the :data namespace will be visited,
+    # but nothing there will be discarded.
+    @gen function loopy()
+        a = @trace(normal(0, 1), :a)
+        for i=1:5
+            @trace(normal(a, 1), :data => i)
+        end
+    end
+
+    # Get an initial trace
+    constraints = choicemap()
+    constraints[:a] = 0
+    for i=1:5
+        constraints[:data => i] = 0
+    end
+    (trace,) = generate(loopy, (), constraints)
+
+    # Update a
+    constraints = choicemap()
+    constraints[:a] = 1
+    (new_trace, weight, retdiff, discard) = update(trace,
+        (), (), constraints)
+
+    # Test discard, score, weight, retdiff
+    @test get_value(discard, :a) == 0
+    prev_score = logpdf(normal, 0, 0, 1) * 6
+    expected_new_score = logpdf(normal, 1, 0, 1) + 5 * logpdf(normal, 0, 1, 1)
+    expected_weight = expected_new_score - prev_score
+    @test isapprox(expected_new_score, get_score(new_trace))
+    @test isapprox(expected_weight, weight)
+    @test retdiff === UnknownChange()
 end
 
 @testset "regenerate" begin
@@ -426,53 +394,38 @@ end
 end
 
 @testset "multi-component addresses" begin
-    for notation in [:trace, :tilde]
-        if notation == :trace
-            @gen function bar()
-                @trace(normal(0, 1), :z)
-            end
-
-            @gen function foo()
-                @trace(normal(0, 1), :y)
-                @trace(normal(0, 1), :x => 1)
-                @trace(normal(0, 1), :x => 2)
-                @trace(bar(), :x => 3)
-            end
-        else
-            @gen function bar()
-                z ~ normal(0, 1)
-            end
-
-            @gen function foo()
-                y ~ normal(0, 1)
-                {:x => 1} ~ normal(0, 1)
-                {:x => 2} ~ normal(0, 1)
-                {:x => 3} ~ bar()
-            end
-        end
-
-        trace, _ =  generate(foo, (), choicemap((:x => 1, 1), (:x => 2, 2), (:x => 3 => :z, 3)))
-        @test trace[:x => 1] == 1
-        @test trace[:x => 2] == 2
-        @test trace[:x => 3 => :z] == 3
-
-        choices = get_choices(trace)
-        @test choices[:x => 1] == 1
-        @test choices[:x => 2] == 2
-        @test choices[:x => 3 => :z] == 3
-        @test length(collect(get_values_shallow(choices))) == 1 # :y
-        @test length(collect(get_submaps_shallow(choices))) == 1 # :x
-
-        submap = get_submap(choices, :x)
-        @test submap[1] == 1
-        @test submap[2] == 2
-        @test submap[3 => :z] == 3
-        @test length(collect(get_values_shallow(submap))) == 2 # 1, 2
-        @test length(collect(get_submaps_shallow(submap))) == 1 # 3
-
-        bar_submap = get_submap(submap, 3)
-        @test bar_submap[:z] == 3
+    @gen function bar()
+        @trace(normal(0, 1), :z)
     end
+
+    @gen function foo()
+        @trace(normal(0, 1), :y)
+        @trace(normal(0, 1), :x => 1)
+        @trace(normal(0, 1), :x => 2)
+        @trace(bar(), :x => 3)
+    end
+
+    trace, _ =  generate(foo, (), choicemap((:x => 1, 1), (:x => 2, 2), (:x => 3 => :z, 3)))
+    @test trace[:x => 1] == 1
+    @test trace[:x => 2] == 2
+    @test trace[:x => 3 => :z] == 3
+
+    choices = get_choices(trace)
+    @test choices[:x => 1] == 1
+    @test choices[:x => 2] == 2
+    @test choices[:x => 3 => :z] == 3
+    @test length(collect(get_values_shallow(choices))) == 1 # :y
+    @test length(collect(get_submaps_shallow(choices))) == 1 # :x
+
+    submap = get_submap(choices, :x)
+    @test submap[1] == 1
+    @test submap[2] == 2
+    @test submap[3 => :z] == 3
+    @test length(collect(get_values_shallow(submap))) == 2 # 1, 2
+    @test length(collect(get_submaps_shallow(submap))) == 1 # 3
+
+    bar_submap = get_submap(submap, 3)
+    @test bar_submap[:z] == 3
 end
 
 @testset "project" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
 """
 Compute a numerical partial derivative of `f` with respect to the `i`th argument, a symettric matrix, using finite differences.
 
-Finite differences are applied symettrically to off-diagonal elements of the matrix, ensuring that the modified matrix is still symettric. 
+Finite differences are applied symettrically to off-diagonal elements of the matrix, ensuring that the modified matrix is still symettric.
 
 When applied to off-diagonal elements, the finite difference is scaled by a factor of 1/2.
 
@@ -52,13 +52,13 @@ function finite_diff_mat_sym(f::Function, args::Tuple, i::Int, j::Int, k::Int, d
     pos_args[i][j, k] += dx
     neg_args = Any[deepcopy(args)...]
     neg_args[i][j, k] -= dx
-    
+
     if j!=k
         pos_args[i][k, j] += dx
         neg_args[i][k, j] -= dx
         return (f(pos_args...) - f(neg_args...)) / (4. * dx)
     end
-    
+
     return (f(pos_args...) - f(neg_args...)) / (2. * dx)
 end
 
@@ -71,5 +71,6 @@ include("assignment.jl")
 include("dynamic_dsl.jl")
 include("static_ir/static_ir.jl")
 include("static_dsl.jl")
+include("tilde_sugar.jl")
 include("inference/inference.jl")
 include("modeling_library/modeling_library.jl")

--- a/test/tilde_sugar.jl
+++ b/test/tilde_sugar.jl
@@ -1,0 +1,89 @@
+using Gen
+import MacroTools
+
+normalize(ex) = MacroTools.prewalk(MacroTools.rmlines, ex)
+
+
+
+# dynamic
+@testset "tilde syntax smoke test (dynamic)" begin
+    @gen function foo(a, b)
+        p ~ beta(a, b)
+        return ({:coin => 1} ~ bernoulli(p)) + ({:coin => 2} ~ bernoulli(p))
+    end
+
+    trace = simulate(foo, (1, 1))
+    @test (trace[:coin => 1] + trace[:coin => 2]) == get_retval(trace)
+    @test get_score(trace) == sum([(trace[:coin => i] ? log(trace[:p]) : log(1-trace[:p])) for i=1:2])
+end
+
+@testset "tilde syntax desugars as expected (dynamic)" begin
+    expected = normalize(:(
+    @gen function foo()
+        x = @trace(normal(0, 1), :x)
+        y = @trace(normal(0, 1), :y => :z)
+        z = @trace(bar())
+    end))
+
+    actual = normalize(Gen.desugar_tildes(:(
+    @gen function foo()
+        x ~ normal(0, 1)
+        y = ({:y => :z} ~ normal(0, 1))
+        z = ({*} ~ bar())
+    end)))
+
+    @test actual == expected
+end
+
+# static
+
+
+@testset "tilde syntax smoke test (static)" begin
+    @gen (static) function bar(r)
+        a ~ normal(0, 1)
+        return r
+    end
+
+    @gen (static) function foo()
+        x ~ bar(1)
+        yz = {:y => :z} ~ bar(2)
+        u ~ normal(0, 1)
+        {:v => :w} ~ normal(0, 1)
+        retrate = 7
+        return {:ret} ~ poisson(retrate)
+    end
+
+    Gen.load_generated_functions()
+
+    trace = simulate(foo, ())
+
+    # random choices
+    @test trace[:u] isa Float64
+    @test trace[:v => :w] isa Float64
+    @test trace[:x => :a] isa Float64
+    @test trace[:y => :z => :a] isa Float64
+
+    # auxiliary state
+    @test trace[:x] == 1
+    @test trace[:y => :z] == 2
+
+    # return value
+    @test trace[] == trace[:ret]
+end
+
+
+@testset "tilde syntax desugars as expected (static)" begin
+expected = normalize(:(
+@gen (static) function foo()
+    x = @trace(normal(0, 1), :x)
+    y = @trace(normal(0, 1), :y)
+end))
+
+actual = normalize(Gen.desugar_tildes(:(
+@gen (static) function foo()
+    x ~ normal(0, 1)
+    y = ({:y} ~ normal(0, 1))
+end)))
+
+@test actual == expected
+end


### PR DESCRIPTION
This pull request adds the following syntactic sugar to the two `@gen` modeling DSLs:

Sugar|Desugars to
-----|-----------
`x ~ e`|`x = @trace(e, :x)`
`{a} ~ e`|`@trace(e, a)`
`{*} ~ e`|`@trace(e)`

For example:

```julia
@gen function linear_regression(xs)
  # Assign variables and give the choices addresses at the same time
  slope ~ normal(0, 1)
  intercept ~ normal(0, 1)
  prob_outliers ~ uniform(0, 0.5)

  for (i, x) in enumerate(xs)
    # A tilde expression can appear anywhere, but should be
    # surrounded by parentheses (otherwise precedence is too low).
    if ({:is_outlier => i} ~ bernoulli(prob_outliers))
      {:y => i} ~ normal(0, 10)
    else
      {:y => i} ~ normal(slope * x + intercept, 1)
    end
  end
end
```

Some notes:

The precedence of the tilde operator is relatively weak. So, for example, the parentheses in the code `if (b ~ bernoulli(0.4)); x; else; y; end` are required.

Currently, we do not allow expressions like `x[3] ~ normal(0, 1)` or `(x, y) ~ f()` or `x.y ~ normal(0, 1)`. All of these are in theory possible to support -- we just need to decide on a convention for converting the left-hand side into an address. There is a function, `address_from_expression`, for doing this -- right now it only supports symbols, but that should be easy to change by editing this function.

I wasn't sure what the best way to test this was, so I modified some of the existing tests to run twice, with and without tilde syntax. Let me know if you'd prefer a different unit testing strategy :-)

I haven't yet added/changed documentation. If people like the syntax, we may decide to shift docs and tutorials to use tilde by default; otherwise, we can just describe the sugar as being an option.