### PR TITLE
Add geometric to list of built-in distributions in the docs.

### DIFF
--- a/docs/src/ref/distributions.md
+++ b/docs/src/ref/distributions.md
@@ -10,6 +10,7 @@ gamma
 inv_gamma
 beta
 categorical
+geometric
 uniform
 uniform_discrete
 poisson
@@ -18,4 +19,3 @@ beta_uniform
 exponential
 laplace
 ```
-


### PR DESCRIPTION
For whatever reason, `geometric` is missing from the docs. This actually led me to implement `geometric` as a series of `bernoulli` flips during my first attempt to use Gen, because I thought Gen just didn't support geometric distributions.