### PR TITLE
Document a definition of "sample space", "support", "disciplined generative function", and adjust the behavior of `logpdf` accordingly

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -121,7 +121,8 @@ Gen's built in modeling languages require that a address is associated with a fi
 end
 ```
 
-A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, there exists a set S that is a subset of the sample space such that for all executions of the generative function, if an address appears in the execution, its support must be S. Violating this discipline will cause NaNs, errors, or undefined behavior in certain inference programs. However, there are many inference programs where violating this discipline does not result in undefined behavior and is convenient.
+A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, for each address `a` there exists a set S that is a subset of the sample space such that for all executions of the generative function, if `a` occurs as the address of a choice in the execution, the support of that choice must be exactly S. Violating this discipline will cause NaNs, errors, or undefined behavior in some inference programs. However, there are many inference programs where violating this discipline does not result in undefined behavior and is convenient.
+Authors of inference programs should document which kinds of undisciplined models their inference algorithms allow or expect to see.
 
 If the support of a random choice needs to change, a disciplined generative function can represent this by using a different address for each distinct value of the support. For example, consider the following generative function:
 ```julia

--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -97,11 +97,33 @@ val::Bool = @trace(bernoulli(0.5), :z)
 Not all random choices need to be given addresses.
 An address is required if the random choice will be observed, or will be referenced by a custom inference algorithm (e.g. if it will be proposed to by a custom proposal distribution).
 
-### Choices should have constant support
-The support of a random choice at a given address (the set of values with nonzero probability or probability density) must be constant across all possible executions of the `@gen` function.
-Violating this discipline will cause errors in certain cases.
-If the support of a random choice needs to change, use a different address for each distinct value of the support.
-For example, consider the following generative function:
+
+### Sample space and support of random choices
+
+Different probability distributions produce different types of values for their random choices. For example, the [`Bernoulli`](@ref) distribution results in `Bool` values (either `true` or `false`), the [`Normal`](@ref) distribution results in `Real` values that may be positive or negative, and the [`Beta`](@ref) distributions result in `Real` values that are always in the unit interval (0, 1).
+
+Each [`Distribution`](@ref) is associated with two sets of values:
+
+- The **sample space** of the distribution, which does not depend on the arguments.
+
+- The **support** of the distribution, which may depend on the arguments, and is the set of values that has nonzero probability (or probability density). It may be the entire sample space, or it may be a subset of the sample space.
+
+For example, the sample space of [`Bernoulli`](@ref) is `Bool` and its support is either `{true}`, `{false}`, or `{true, false}`. The sample space of [`Normal`](@ref) is `Real` and its support is the set of all values on the real line. The sample space of [`Beta`](@ref) is `Real` and its support is the set of values in the interval (0, 1).
+
+Gen's built in modeling languages require that a address is associated with a fixed sample space. For example, it is not permitted to use a `Bernoulli` distribution to sample at addresss `:a` in one execution, and a `Normal` distribution to sample at address `:a` in a different execution, because their sample spaces differ (`Bool` vs `Real`):
+```julia
+@gen function foo()
+    if @trace(bernoulli(0.5), :branch)
+        @trace(bernoulli(0.5), :x)
+    else
+        @trace(normal(0, 1), :x)
+    end
+end
+```
+
+A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, there exists a set S that is a subset of the sample space such that for all executions of the generative function, if an address appears in the execution, its support must be S. Violating this discipline will cause NaNs, errors, or undefined behavior in certain inference programs. However, there are many inference programs where violating this discipline does not result in undefined behavior and is convenient.
+
+If the support of a random choice needs to change, a disciplined generative function can represent this by using a different address for each distinct value of the support. For example, consider the following generative function:
 ```julia
 @gen function foo()
     n = @trace(categorical([0.5, 0.5]), :n) + 1
@@ -109,19 +131,12 @@ For example, consider the following generative function:
 end
 ```
 The support of the random choice with address `:x` is either the set ``\{1, 2\}`` or ``\{1, 2, 3\}``.
-Therefore, this random choice does satisfy our condition above.
-This would cause an error with the following, in which the `:n` address is modified, which could result in a change to the domain of the `:x` variable:
+Therefore, this random choice does not have constant support, and the generative function `foo` is not 'disciplined'.
+Specifically, this could result in undefined behavior for the following inference program:
 ```julia
-tr, _ = generate(foo, (), choicemap((:n, 2), (:x, 3)))
-tr, _ = mh(tr, select(:n))
+tr, _ = importance_resampling(foo, (), choicemap((:x, 3)))
 ```
-We can modify the address to satisfy the condition by including the domain in the address:
-```julia
-@gen function foo()
-    n = @trace(categorical([0.5, 0.5]), :n) + 1
-    @trace(categorical(ones(n) / n), (:x, n))
-end
-```
+It is recommended to write disciplined generative functions when possible.
 
 ## Calling generative functions
 

--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -121,8 +121,8 @@ Gen's built in modeling languages require that a address is associated with a fi
 end
 ```
 
-A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, for each address `a` there exists a set S that is a subset of the sample space such that for all executions of the generative function, if `a` occurs as the address of a choice in the execution, the support of that choice must be exactly S. Violating this discipline will cause NaNs, errors, or undefined behavior in some inference programs. However, there are many inference programs where violating this discipline does not result in undefined behavior and is convenient.
-Authors who want their inference code to be reusable should consider documenting which kinds of undisciplined models their inference algorithms allow or expect to see.
+A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, for each address `a` there must exist a set S that is a subset of the sample space such that for all executions of the generative function, if `a` occurs as the address of a choice in the execution, then the support of that choice is exactly S. Violating this discipline will cause NaNs, errors, or undefined behavior in some inference programs. However, in many cases it is convenient to write an inference program that operates correctly and efficiently on some specialized class of undisciplined models.
+In these cases, authors who want their inference code to be reusable should consider documenting which kinds of undisciplined models their inference algorithms allow or expect to see.
 
 If the support of a random choice needs to change, a disciplined generative function can represent this by using a different address for each distinct value of the support. For example, consider the following generative function:
 ```julia

--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -122,7 +122,7 @@ end
 ```
 
 A generative function can be **disciplined** or not. In a disciplined generative function, the support of random choices at each address must be fixed. That is, for each address `a` there exists a set S that is a subset of the sample space such that for all executions of the generative function, if `a` occurs as the address of a choice in the execution, the support of that choice must be exactly S. Violating this discipline will cause NaNs, errors, or undefined behavior in some inference programs. However, there are many inference programs where violating this discipline does not result in undefined behavior and is convenient.
-Authors of inference programs should document which kinds of undisciplined models their inference algorithms allow or expect to see.
+Authors who want their inference code to be reusable should consider documenting which kinds of undisciplined models their inference algorithms allow or expect to see.
 
 If the support of a random choice needs to change, a disciplined generative function can represent this by using a different address for each distinct value of the support. For example, consider the following generative function:
 ```julia

--- a/src/inference/inference.jl
+++ b/src/inference/inference.jl
@@ -2,12 +2,12 @@ import Random
 
 function logsumexp(arr::AbstractArray{T}) where {T <: Real}
     max_arr = maximum(arr)
-    max_arr + log(sum(exp.(arr .- max_arr)))
+    max_arr == -Inf ? -Inf : max_arr + log(sum(exp.(arr .- max_arr)))
 end
 
 function logsumexp(x1::Real, x2::Real)
-    max_arr = max(x1, x2)
-    max_arr + log(exp(x1 - max_arr) + exp(x2 - max_arr))
+    m = max(x1, x2)
+    m == -Inf ? m : m + log(exp(x1 - m) + exp(x2 - m))
 end
 
 export logsumexp

--- a/src/modeling_library/beta.jl
+++ b/src/modeling_library/beta.jl
@@ -11,7 +11,8 @@ Sample a `Float64` from a beta distribution.
 const beta = Beta()
 
 function logpdf(::Beta, x::Real, alpha::Real, beta::Real)
-    (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - logbeta(alpha, beta)
+    (x < 0 || x > 1 ? -Inf :
+    (alpha - 1) * log(x) + (beta - 1) * log1p(-x) - logbeta(alpha, beta) )
 end
 
 function logpdf_grad(::Beta, x::Real, alpha::Real, beta::Real)

--- a/src/modeling_library/beta_uniform.jl
+++ b/src/modeling_library/beta_uniform.jl
@@ -10,9 +10,13 @@ Samples a `Float64` value from a mixture of a uniform distribution on [0, 1] wit
 const beta_uniform = BetaUniformMixture()
 
 function logpdf(::BetaUniformMixture, x::Real, theta::Real, alpha::Real, beta::Real)
-    lbeta = log(theta) + logpdf(Beta(), x, alpha, beta)
-    luniform = log(1.0 - theta)
-    logsumexp(lbeta, luniform)
+    if x < 0 || x > 1
+        -Inf
+    else
+        lbeta = log(theta) + logpdf(Beta(), x, alpha, beta)
+        luniform = log(1.0 - theta)
+        logsumexp(lbeta, luniform)
+    end
 end
 
 function logpdf_grad(::BetaUniformMixture, x::Real, theta::Real, alpha::Real, beta::Real)

--- a/src/modeling_library/categorical.jl
+++ b/src/modeling_library/categorical.jl
@@ -8,7 +8,7 @@ Given a vector of probabilities `probs` where `sum(probs) = 1`, sample an `Int` 
 const categorical = Categorical()
 
 function logpdf(::Categorical, x::Int, probs::AbstractArray{U,1}) where {U <: Real}
-    log(probs[x])
+    (x > 0 && x <= length(probs)) ? log(probs[x]) : -Inf
 end
 
 function logpdf_grad(::Categorical, x::Int, probs::AbstractArray{U,1})  where {U <: Real}

--- a/src/modeling_library/dist/relabeled_distribution.jl
+++ b/src/modeling_library/dist/relabeled_distribution.jl
@@ -12,7 +12,7 @@ function logpdf(d::WithLabelArg{T, U}, x::T, collection, base_args...) where {T,
                 push!(logprobs, logpdf(d.base, index, base_args...))
             end
         end
-        logsumexp(logprobs)
+        isempty(logprobs) ? -Inf : logsumexp(logprobs)
     else
         error("Cannot relabel a continuous distribution")
     end
@@ -66,7 +66,7 @@ function logpdf(d::RelabeledDistribution{T, U}, x::T, base_args...) where {T, U}
                 push!(logprobs, logpdf(d.base, index, base_args...))
             end
         end
-        logsumexp(logprobs)
+        isempty(logprobs) ? -Inf : logsumexp(logprobs)
     else
         error("Cannot relabel a continuous distribution")
     end

--- a/src/modeling_library/mvnormal.jl
+++ b/src/modeling_library/mvnormal.jl
@@ -8,13 +8,13 @@ Samples a `Vector{Float64}` value from a multivariate normal distribution.
 const mvnormal = MultivariateNormal()
 
 function logpdf(::MultivariateNormal, x::AbstractVector{T}, mu::AbstractVector{U},
-                cov::AbstractMatrix{V}) where {T,U,V}
+                cov::AbstractMatrix{V}) where {T <: Real, U <: Real, V <: Real}
     dist = Distributions.MvNormal(mu, cov)
     Distributions.logpdf(dist, x)
 end
 
 function logpdf_grad(::MultivariateNormal, x::AbstractVector{T}, mu::AbstractVector{U},
-                cov::AbstractMatrix{V}) where {T,U,V}
+                cov::AbstractMatrix{V}) where {T <: Real,U <: Real, V <: Real}
     dist = Distributions.MvNormal(mu, cov)
     inv_cov = Distributions.invcov(dist)
 
@@ -26,7 +26,7 @@ function logpdf_grad(::MultivariateNormal, x::AbstractVector{T}, mu::AbstractVec
 end
 
 function random(::MultivariateNormal, mu::AbstractVector{U},
-                cov::AbstractMatrix{V}) where {T,U,V}
+                cov::AbstractMatrix{V}) where {U <: Real, V <: Real}
     rand(Distributions.MvNormal(mu, cov))
 end
 

--- a/src/modeling_library/piecewise_uniform.jl
+++ b/src/modeling_library/piecewise_uniform.jl
@@ -36,9 +36,10 @@ function logpdf(::PiecewiseUniform, x::Real, bounds::AbstractVector{T},
     # |    probs[1]  |  probs[2]         | probs[3]     |
     if x <= bounds[1] || x >= bounds[end]
         -Inf
+    else
+        bin = get_bin(bounds, x)
+        log(probs[bin]) - log(bounds[bin+1] - bounds[bin])
     end
-    bin = get_bin(bounds, x)
-    log(probs[bin]) - log(bounds[bin+1] - bounds[bin])
 end
 
 function random(::PiecewiseUniform, bounds::Vector{T},

--- a/src/modeling_library/poisson.jl
+++ b/src/modeling_library/poisson.jl
@@ -8,12 +8,11 @@ Sample an `Int` from the Poisson distribution with rate `lambda`.
 const poisson = Poisson()
 
 function logpdf(::Poisson, x::Integer, lambda::Real)
-    x * log(lambda) - lambda - loggamma(x+1)
+    x < 0 ? -Inf : x * log(lambda) - lambda - loggamma(x+1)
 end
 
 function logpdf_grad(::Poisson, x::Integer, lambda::Real)
-    error("Not implemented")
-    (nothing, nothing)
+    (nothing, x/lambda - 1)
 end
 
 

--- a/src/modeling_library/poisson.jl
+++ b/src/modeling_library/poisson.jl
@@ -7,11 +7,11 @@ Sample an `Int` from the Poisson distribution with rate `lambda`.
 """
 const poisson = Poisson()
 
-function logpdf(::Poisson, x::Integer, lambda::Real)
+function logpdf(::Poisson, x::Int, lambda::Real)
     x < 0 ? -Inf : x * log(lambda) - lambda - loggamma(x+1)
 end
 
-function logpdf_grad(::Poisson, x::Integer, lambda::Real)
+function logpdf_grad(::Poisson, x::Int, lambda::Real)
     (nothing, x/lambda - 1)
 end
 

--- a/test/modeling_library/dist.jl
+++ b/test/modeling_library/dist.jl
@@ -4,12 +4,18 @@
 
   @dist labeled_cat(labels, probs) = labels[categorical(probs)]
   @test labeled_cat([:a, :b], [0., 1.]) == :b
+  @test isapprox(logpdf(labeled_cat, :b, [:a, :b], [0.5, 0.5]), log(0.5))
+  @test logpdf(labeled_cat, :c, [:a, :b], [0.5, 0.5]) == -Inf
 
   dict = Dict(1 => :a, 2 => :b)
   @dist dict_cat(probs) = dict[categorical(probs)]
   @test dict_cat([0., 1.]) == :b
+  @test isapprox(logpdf(dict_cat, :b, [0.5, 0.5]), log(0.5))
+  @test logpdf(dict_cat, :c, [0.5, 0.5]) == -Inf
 
   @enum Fruit apple orange
   @dist enum_cat(probs) = Fruit(categorical(probs) - 1)
   @test enum_cat([0., 1.]) == orange
+  @test isapprox(logpdf(enum_cat, orange, [0.5, 0.5]), log(0.5))
+  @test logpdf(enum_cat, orange, [1.0]) == -Inf
 end


### PR DESCRIPTION
Currently, `logpdf` has inconsistent behavior across distributions as to what it returns for values outside the support of the distribution. For example, distributions that are implemented by wrapping the corresponding distribution in `Distributions.jl` return `-Inf` outside their support, but `categorical` and `beta` throw errors.

This pull request addresses this inconsistent behavior, ensuring that all distributions return -Inf when queried outside of their support. A summary of changes:

- Works for both built-in and `@dist` distributions.
- Test cases added accordingly (including tests for distributions which had lacked tests altogether).
- `logsumexp` implementation adjusted to handle `-Inf`.
- `logpdf_grad` implemented for `Poisson` because it was missing.

This change should also guarantee that importance sampling doesn't lead to errors when proposal distributions have wider support than the corresponding target distributions. This is useful in a number of cases, such as using a normal as a proposal distribution to a variable sampled from a distribution with support only over the positive reals. Consider, for example, trying to infer a latent variable `x ~ exponential(1)`  from a noisy Gaussian observation of `y ~ normal(x, 0.5)`:

```
@gen function model()
    x ~ exponential(1)
    y ~ normal(x, 0.5)
end
```

If `y` is observed to have a large value, e.g. `y=5`, importance sampling using the prior as the proposal is going to lead to a high variance estimate. We could instead have a proposal that proposes `x` to be centered around `y`:

```
@gen function proposal(y)
    x ~ normal(y, 0.5)
end
```

This will lead to traces being proposed that are much more likely given the constraints, leading to a good estimate of `x` with less traces. But very occasionally, `x` might be proposed to be less than 0, which is impossible under the model. Still, we don't want importance sampling to just throw an error if this happens. Rather, it seems better if we just assign that trace `-Inf` log weight, and carry on sampling. The changes in this pull request should ensure that those sorts of error doesn't occur.

(Note that I haven't tested the specific example given above -- I just believe it should work given the current implementations of `importance_sampling` and `importance_resampling`, which rely upon `logsumexp`, which has been adjusted in this pull request to correctly handle `-Inf` weights instead of returning `NaN`s.)