### PR TITLE
One-line change to support one-line generative function definitions.

### DIFF
--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -86,6 +86,7 @@ function desugar_tildes(expr)
 end
 
 function parse_gen_function(ast, annotations)
+    ast = longdef(ast)
     if ast.head != :function
         error("syntax error at $ast in $(ast.head)")
     end

--- a/test/dynamic_dsl.jl
+++ b/test/dynamic_dsl.jl
@@ -23,7 +23,11 @@ end
         return x
     end
 
-    @test baz(5) == 5    
+    @test baz(5) == 5
+
+    @gen (grad) oneliner(x::Float64, (grad)(y::Float64=5)) = x+y
+
+    @test oneliner(5) == 10
 end
 
 @testset "return type" begin

--- a/test/optional_args.jl
+++ b/test/optional_args.jl
@@ -194,12 +194,11 @@ end
     tr, w = zip([generate(bar1, (1, 1), constraints) for i in 1:100]...)
     @test all(get_retval.(tr) .>= 2)
 
-    @gen function new_prod(d::Int)
+    @gen new_prod(d::Int) =
         @trace(production(d, 2))
-    end
-    @gen function new_aggr(d::Int, cvals::Vector)
+    @gen new_aggr(d::Int, cvals::Vector) =
         @trace(aggregation(d, cvals, xs -> join(string.(xs))))
-    end
+
     bar2 = Recurse(new_prod, new_aggr, 2, Int, Int, Any)
     constraints = choicemap()
     constraints[(1, Val(:production)) => :branch] = true

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -430,5 +430,16 @@ end
     @test String(take!(io)) == "my documentation\n"
 end
 
+@testset "one-line definitions" begin
+
+@gen (static) foo(x) = (y = @trace(normal(x, 1), :y); return y)
+
+load_generated_functions()
+
+tr, w = generate(foo, (0,), choicemap(:y => 1))
+@test get_retval(tr) == 1
+@test isapprox(w, logpdf(normal, 1, 0, 1))
+
+end
 
 end # @testset "static DSL"


### PR DESCRIPTION
Thanks to `MacroTools`, we can support one line `@gen` definitions with a one-line change to the parsing code! :)

This makes for more compact code when we need to define variants of a template generative function that fix some of the arguments to specific / new defaults, e.g.:
```julia
@gen sample_rectangle(width, height) = ({:x} ~ uniform(0, width), {:y} ~ uniform(0, height))
@gen sample_square(side) = {*} ~ sample_rectangle(side, side)
```

Hopefully a less controversial pull request than my last one :P

