### PR TITLE
Support type annotations in the @dist DSL.

### DIFF
--- a/src/modeling_library/dist/dist_dsl.jl
+++ b/src/modeling_library/dist/dist_dsl.jl
@@ -5,16 +5,15 @@ include("relabeled_distribution.jl")
 
 #TODO: Remove Distribution{T} from structs; use a type U instead
 
-
 # `Arg` types: represent arguments to distributions
-abstract type Arg end
+abstract type Arg{T} end
 
 # Represents a argument at a certain index
-struct SimpleArg <: Arg
+struct SimpleArg{T} <: Arg{T}
     i :: Int8
 end
 
-struct TransformedArg <: Arg
+struct TransformedArg{T} <: Arg{T}
     f_args :: Vector{Arg} # Is it better to do Union{TransformedArg, SimpleArg}?
     orig_f :: Function
     arg_passer :: Function
@@ -26,12 +25,14 @@ end
 all_indices(arg::SimpleArg) = [arg.i]
 all_indices(arg::TransformedArg) = vcat([all_indices(a) for a in arg.f_args]...)
 
+# Evaluate user-facing args to concrete values passed to the base distribution
 eval_arg(x::Any, args) = x
-eval_arg(x::SimpleArg, args) = args[x.i]
-eval_arg(x::TransformedArg, args) = x.arg_passer(x.orig_f, [eval_arg(a, args) for a in x.f_args]...)
+eval_arg(x::SimpleArg, args) = typecheck_arg(x, args[x.i])
+eval_arg(x::TransformedArg, args) =
+    x.arg_passer(x.orig_f, [eval_arg(a, args) for a in x.f_args]...)
 
-
-
+# Type of SimpleArg must match arg, otherwise a MethodError will be thrown
+typecheck_arg(x::SimpleArg{T}, arg::T) where {T} = arg
 
 # DistWithArgs
 struct DistWithArgs{T}
@@ -45,7 +46,6 @@ struct CompiledDistWithArgs{T} <: Distribution{T}
     arg_grad_bools
     arglist
 end
-
 
 function compile_dist_with_args(d::DistWithArgs{T}, n::Int8)::CompiledDistWithArgs{T} where T
     base_arg_grads = has_argument_grads(d.base)
@@ -65,7 +65,6 @@ function logpdf(d::CompiledDistWithArgs{T}, x::T, args...) where T
     logpdf(d.base, x, concrete_args...)
 end
 
-
 function logpdf_grad(d::CompiledDistWithArgs{T}, x::T, args...) where T
     self_has_output_grad = has_output_grad(d)
     self_has_arg_grads = has_argument_grads(d)
@@ -73,9 +72,11 @@ function logpdf_grad(d::CompiledDistWithArgs{T}, x::T, args...) where T
     base_has_arg_grads = has_argument_grads(d.base)
     base_grads = logpdf_grad(d.base, x, concrete_args...)
 
-    base_arg_grads = [g for (i, g) in enumerate(base_grads[2:end]) if base_has_arg_grads[i]]
+    base_arg_grads = [g for (i, g) in enumerate(base_grads[2:end])
+                      if base_has_arg_grads[i]]
     argvec = collect(args)
-    eval_arg_grads = hcat([ReverseDiff.gradient(xs -> eval_arg(arg, xs), argvec) for (i, arg) in enumerate(d.arglist) if base_has_arg_grads[i]]...)
+    eval_arg_grads = hcat([ReverseDiff.gradient(xs -> eval_arg(arg, xs), argvec)
+        for (i, arg) in enumerate(d.arglist) if base_has_arg_grads[i]]...)
 
     retval = [base_grads[1]]
     for i in 1:d.n_args
@@ -105,24 +106,21 @@ function has_argument_grads(d::CompiledDistWithArgs{T}) where T
     d.arg_grad_bools
 end
 
-
-
 # ACTUAL DSL
-
 
 # A function call within a @dist body
 function dist_call(d::Distribution{T}, args) where T
     DistWithArgs{T}(d, args)
 end
+
 function dist_call(f, args)
     if any(x -> (typeof(x) <: DistWithArgs), args)
         f(args...)
     elseif any(x -> (typeof(x) <: Arg), args)
-        # Create a transformed distribution
+        # Create a transformed argument
         f_args = []
         new_f_arg_names = []
         actual_arg_exprs = []
-
         for (i, x) in enumerate(args)
             if typeof(x) <: Arg
                 push!(f_args, x)
@@ -134,7 +132,7 @@ function dist_call(f, args)
             end
         end
         arg_passer = eval(:((f, $(new_f_arg_names...)) -> f($(actual_arg_exprs...))))
-        TransformedArg(f_args, f, arg_passer)
+        TransformedArg{Any}(f_args, f, arg_passer)
     else
         f(args...)
     end
@@ -145,24 +143,20 @@ end
 macro dist(fnexpr)
   # First, pull out arguments and body
   fndef = splitdef(longdef(fnexpr))
-  #
-  # if !@capture(fnexpr, argexpr_ -> body_)
-  #     error("@dist expression must be of the form @dist (args...) -> body")
-  # end
-  # arguments = (typeof(argexpr) == Symbol) ? (argexpr,) : argexpr.args # [] #argexpr
-
   arguments = fndef[:args]
   body = fndef[:body]
 
   name_to_index = Dict{Symbol, Int8}()
+  name_to_type = Dict{Symbol, Type}()
   for (i, arg) in enumerate(arguments)
-      (argname, _, _, _) = splitarg(arg)
+      (argname, argtype, _, _) = splitarg(arg)
       name_to_index[argname] = i
+      name_to_type[argname] = eval(argtype)
   end
 
   function process_node(node)
       if typeof(node) == Symbol && haskey(name_to_index, node)
-          return :($(SimpleArg(name_to_index[node])))
+          return :($(SimpleArg{name_to_type[node]}(name_to_index[node])))
       end
       if @capture(node, f_(xs__)) && f != :dist_call
           return :(Gen.dist_call($(f), ($(xs...),)))
@@ -171,45 +165,65 @@ macro dist(fnexpr)
   end
 
   dwa_expr = MacroTools.postwalk(process_node, body)
-  :($(esc(fndef[:name])) = compile_dist_with_args($(esc(dwa_expr)), Int8($(length(arguments)))))
+  :($(esc(fndef[:name])) =
+    compile_dist_with_args($(esc(dwa_expr)), Int8($(length(arguments)))))
 end
 
-
-
 # Addition
-Base.:+(b::DistWithArgs{T}, a::Real) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x + a, x -> x - a, x -> (1.0,)), b.arglist)
-Base.:+(b::DistWithArgs{T}, a::Arg) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, +, -, (x, a) -> (1.0, -1.0)), (a, b.arglist...))
+Base.:+(b::DistWithArgs{T}, a::Real) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x + a, x -> x - a, x -> (1.0,)), b.arglist)
+Base.:+(b::DistWithArgs{T}, a::Arg) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, +, -, (x, a) -> (1.0, -1.0)), (a, b.arglist...))
 Base.:+(a::Real, b::DistWithArgs{T}) where T <: Real = b + a
 Base.:+(a::Arg, b::DistWithArgs{T}) where T <: Real = b + a
 
 # Subtraction
 Base.:-(b::DistWithArgs{T}, a::Real) where T <: Real = b + (-1 * a)
-Base.:-(b::DistWithArgs{T}, a::Arg) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, -, +, (x, a) -> (1.0, 1.0)), (a, b.arglist...))
-Base.:-(a::Real, b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, x -> a - x, x -> a - x, x -> (-1.0,)), b.arglist)
-Base.:-(a::Arg, b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, (x, a) -> a - x, (x, a) -> a - x, (x, a) -> (-1.0, 1.0)), (a, b.arglist...))
+Base.:-(b::DistWithArgs{T}, a::Arg) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, -, +, (x, a) -> (1.0, 1.0)), (a, b.arglist...))
+Base.:-(a::Real, b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, x -> a - x, x -> a - x, x -> (-1.0,)), b.arglist)
+Base.:-(a::Arg, b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, (x, a) -> a - x, (x, a) -> a - x, (x, a) -> (-1.0, 1.0)), (a, b.arglist...))
 
 # Multiplication
-Base.:*(b::DistWithArgs{T}, a::Real) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x * a, x -> x / a, x -> (1.0/a,)), b.arglist)
-Base.:*(b::DistWithArgs{T}, a::Arg) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, *, /, (x, a) -> (1.0/a, -x/(a*a))), (a, b.arglist...))
+Base.:*(b::DistWithArgs{T}, a::Real) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x * a, x -> x / a, x -> (1.0/a,)), b.arglist)
+Base.:*(b::DistWithArgs{T}, a::Arg) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, *, /, (x, a) -> (1.0/a, -x/(a*a))), (a, b.arglist...))
 Base.:*(a::Real, b::DistWithArgs{T}) where T <: Real = b * a
 Base.:*(a::Arg, b::DistWithArgs{T}) where T <: Real = b * a
 
 # Division
-Base.:/(b::DistWithArgs{T}, a::Real) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x / a, x -> x * a, x -> (a,)), b.arglist)
-Base.:/(b::DistWithArgs{T}, a::Arg) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, /, *, (x, a) -> (a, x)), (a, b.arglist...))
-Base.:/(a::Real, b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> a / x, x -> a / x, x -> (-a / (x*x),)), b.arglist)
-Base.:/(a::Arg, b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 1, (x, a) -> a/x, (x, a) -> a/x, (x, a) -> (-a/(x*x), 1.0/x)), (a, b.arglist...))
+Base.:/(b::DistWithArgs{T}, a::Real) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> x / a, x -> x * a, x -> (a,)), b.arglist)
+Base.:/(b::DistWithArgs{T}, a::Arg) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, /, *, (x, a) -> (a, x)), (a, b.arglist...))
+Base.:/(a::Real, b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> a / x, x -> a / x, x -> (-a / (x*x),)), b.arglist)
+Base.:/(a::Arg, b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, (x, a) -> a/x, (x, a) -> a/x, (x, a) -> (-a/(x*x), 1.0/x)), (a, b.arglist...))
 
 # Exponentiation
-Base.exp(b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, exp, log, x -> (1.0 / x,)), b.arglist)
-Base.log(b::DistWithArgs{T}) where T <: Real = DistWithArgs(TransformedDistribution{T, T}(b.base, 0, log, exp, x -> (exp(x),)), b.arglist)
+Base.exp(b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, exp, log, x -> (1.0 / x,)), b.arglist)
+Base.log(b::DistWithArgs{T}) where T <: Real =
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, log, exp, x -> (exp(x),)), b.arglist)
 
 # Indexing
-Base.getindex(collection::Arg, d::DistWithArgs{T}) where T = DistWithArgs{Any}(WithLabelArg{Any, T}(d.base), (collection, d.arglist...))
-Base.getindex(collection::AbstractArray{T}, d::DistWithArgs{U}) where {T, U} = DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
-Base.getindex(collection::AbstractDict{U, T}, d::DistWithArgs{U}) where {T, U} = DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
+Base.getindex(collection::Arg, d::DistWithArgs{T}) where {T} =
+    DistWithArgs{Any}(WithLabelArg{Any, T}(d.base), (collection, d.arglist...))
+Base.getindex(collection::Arg{<:AbstractArray{T}}, d::DistWithArgs{U}) where {T, U} =
+    DistWithArgs{T}(WithLabelArg{T, U}(d.base), (collection, d.arglist...))
+Base.getindex(collection::Arg{<:AbstractDict{U, T}}, d::DistWithArgs{U}) where {T, U} =
+    DistWithArgs{T}(WithLabelArg{T, U}(d.base), (collection, d.arglist...))
+Base.getindex(collection::AbstractArray{T}, d::DistWithArgs{U}) where {T, U} =
+    DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
+Base.getindex(collection::AbstractDict{U, T}, d::DistWithArgs{U}) where {T, U} =
+    DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
 # Ensure no ambiguity with `Base` implementation.
-Base.getindex(collection::Dict{U, T}, d::DistWithArgs{U}) where {T, U} = DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
+Base.getindex(collection::Dict{U, T}, d::DistWithArgs{U}) where {T, U} =
+    DistWithArgs{T}(RelabeledDistribution{T, U}(d.base, collection), d.arglist)
 
 # `Enum` constructors
 function (::Type{T})(d::DistWithArgs{U}) where {T <: Enum, U}

--- a/src/modeling_library/dist/dist_dsl.jl
+++ b/src/modeling_library/dist/dist_dsl.jl
@@ -151,7 +151,7 @@ macro dist(fnexpr)
   for (i, arg) in enumerate(arguments)
       (argname, argtype, _, _) = splitarg(arg)
       name_to_index[argname] = i
-      name_to_type[argname] = eval(argtype)
+      name_to_type[argname] = __module__.eval(argtype)
   end
 
   function process_node(node)

--- a/test/modeling_library/dist.jl
+++ b/test/modeling_library/dist.jl
@@ -18,4 +18,16 @@
   @test enum_cat([0., 1.]) == orange
   @test isapprox(logpdf(enum_cat, orange, [0.5, 0.5]), log(0.5))
   @test logpdf(enum_cat, orange, [1.0]) == -Inf
+
+  @dist symbol_cat(labels::Vector{Symbol}, probs) = labels[categorical(probs)]
+  @test symbol_cat([:a, :b], [0., 1.]) == :b
+  @test_throws MethodError symbol_cat(["a", "b"], [0., 1.])
+  @test logpdf(symbol_cat, :c, [:a, :b], [0.5, 0.5]) == -Inf
+  @test_throws MethodError logpdf(symbol_cat, "c", [:a, :b], [0.5, 0.5])
+
+  @dist int_bounded_uniform(low::Int, high::Int) = uniform(low, high)
+  @test 0.0 <= int_bounded_uniform(0, 1) <= 1
+  @test_throws MethodError int_bounded_uniform(-0.5, 0.5)
+  @test logpdf(int_bounded_uniform, 0.5, 0, 1) == 0
+  @test_throws MethodError logpdf(int_bounded_uniform, 0.0, -0.5, 0.5)
 end

--- a/test/modeling_library/dist.jl
+++ b/test/modeling_library/dist.jl
@@ -1,33 +1,53 @@
-@testset "dist DSL" begin
+@testset "dist DSL (untyped)" begin
+  # Test transformed distributions
   @dist f(x) = exp(normal(x, 0.001))
   @test isapprox(1, f(0); atol = 5)
 
+  # Test relabeled distributions with labels provided as an Array
   @dist labeled_cat(labels, probs) = labels[categorical(probs)]
   @test labeled_cat([:a, :b], [0., 1.]) == :b
   @test isapprox(logpdf(labeled_cat, :b, [:a, :b], [0.5, 0.5]), log(0.5))
   @test logpdf(labeled_cat, :c, [:a, :b], [0.5, 0.5]) == -Inf
 
+  # Test relabeled distributions with labels provided in a Dict
   dict = Dict(1 => :a, 2 => :b)
   @dist dict_cat(probs) = dict[categorical(probs)]
   @test dict_cat([0., 1.]) == :b
   @test isapprox(logpdf(dict_cat, :b, [0.5, 0.5]), log(0.5))
   @test logpdf(dict_cat, :c, [0.5, 0.5]) == -Inf
 
+  # Test relabeled distributions with Enum labels
   @enum Fruit apple orange
   @dist enum_cat(probs) = Fruit(categorical(probs) - 1)
   @test enum_cat([0., 1.]) == orange
   @test isapprox(logpdf(enum_cat, orange, [0.5, 0.5]), log(0.5))
   @test logpdf(enum_cat, orange, [1.0]) == -Inf
+end
 
+# User-defined type for testing purposes
+struct MyLabel
+  name::Symbol
+end
+
+@testset "dist DSL (typed)" begin
+  # Test typed relabeled distributions
   @dist symbol_cat(labels::Vector{Symbol}, probs) = labels[categorical(probs)]
   @test symbol_cat([:a, :b], [0., 1.]) == :b
   @test_throws MethodError symbol_cat(["a", "b"], [0., 1.])
   @test logpdf(symbol_cat, :c, [:a, :b], [0.5, 0.5]) == -Inf
   @test_throws MethodError logpdf(symbol_cat, "c", [:a, :b], [0.5, 0.5])
 
+  # Test typed parameters
   @dist int_bounded_uniform(low::Int, high::Int) = uniform(low, high)
   @test 0.0 <= int_bounded_uniform(0, 1) <= 1
   @test_throws MethodError int_bounded_uniform(-0.5, 0.5)
   @test logpdf(int_bounded_uniform, 0.5, 0, 1) == 0
   @test_throws MethodError logpdf(int_bounded_uniform, 0.0, -0.5, 0.5)
+
+  # Test relabeled distributions with user-defined types
+  @dist mylabel_cat(labels::Vector{MyLabel}, probs) = labels[categorical(probs)]
+  @test mylabel_cat([MyLabel(:a), MyLabel(:b)], [0., 1.]) == MyLabel(:b)
+  @test_throws MethodError mylabel_cat([:a, :b], [0., 1.])
+  @test logpdf(mylabel_cat, MyLabel(:a), [MyLabel(:a)], [1.0]) == 0
+  @test_throws MethodError logpdf(mylabel_cat, :a, [MyLabel(:a)], [1.0])
 end


### PR DESCRIPTION
Currently the `@dist` DSL has limited support for type checking. With the changes in #203, this makes it slightly more dangerous to use user-defined distributions such as:
```julia
@dist labeled_cat(labels, probs) = labels[categorical(probs)]
```
because `labels` could be vector of anything, so the sample space of `labeled_cat` ends up being `Any`, meaning something like `logpdf(labeled_cat, "c", [:a, :b, :c], [0.3, 0.3, 0.4])` will return `-Inf`, rather than erroring.

Sometimes behavior like the above may be useful, if we genuinely do want to sample from a categorical that may have mixed data types. But in lieu of solving the issues raised in #206 (which may require us to distinguish the sample space from the values that are of the correct type), we can still allow users of the `@dist` DSL to be program more defensively by supporting type annotations. This PR enables such functionality, allowing us to write, for e.g.:
```julia
@dist symbol_cat(labels::Vector{Symbol}, probs) = labels[categorical(probs)]
```
`MethodError`s will then be thrown if we try to do either of the following:
```julia
symbol_cat(["a, "b"], [0.5, 0.5]) #Wrong parameter type
logpdf(symbol_cat, "a", [:a, :b], [0.5, 0.5]) #Wrong output type
```

Implementation-wise, type annotations are first captured and stored as a type parameter when `SimpleArg`s are constructed by the `@dist` macro. Type checking is then enforced in two places -- the first in calls to `eval_arg` for `SimpleArg`s, and second in how operators such as `getindex` propagate type information to the distributions they construct.

This PR also reformats the `@dist` DSL code to be a little more readable by trying to stick to the 80-char limit.