### PR TITLE
Refactor parsing for static modeling language and extend supported syntax.

### DIFF
--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -86,7 +86,7 @@ function desugar_tildes(expr)
 end
 
 function parse_gen_function(ast, annotations)
-    ast = longdef(ast)
+    ast = MacroTools.longdef(ast)
     if ast.head != :function
         error("syntax error at $ast in $(ast.head)")
     end

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -56,10 +56,10 @@ choice_or_call_at(gen_fn::GenerativeFunction, addr_typ) = call_at(gen_fn, addr_t
 choice_or_call_at(dist::Distribution, addr_typ) = choice_at(dist, addr_typ)
 
 "Generate informative node name for a Julia expression."
-gen_node_name(arg::Any) = gensym(repr(arg))
+gen_node_name(arg::Any) = gensym(string(arg))
 gen_node_name(arg::Expr) = gensym(arg.head)
 gen_node_name(arg::Symbol) = gensym(arg)
-gen_node_name(arg::QuoteNode) = gensym(repr(arg.value))
+gen_node_name(arg::QuoteNode) = gensym(string(arg.value))
 
 "Parse @trace expression and add corresponding node to IR."
 function parse_trace_expr!(stmts, bindings, fn, args, addr)
@@ -68,7 +68,7 @@ function parse_trace_expr!(stmts, bindings, fn, args, addr)
     node = gen_node_name(addr) # Generate a variable name for the StaticIRNode
     bindings[name] = node
     # Add statement that creates reference to the gen_fn / dist
-    gen_fn_or_dist = gensym(fn)
+    gen_fn_or_dist = gensym(string(fn))
     push!(stmts, :($(esc(gen_fn_or_dist)) = $(esc(fn))))
     # Handle the trace address
     keys = []

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -103,9 +103,10 @@ function parse_assignment!(stmts, bindings, lhs, rhs)
     else
         # Handle single variable assignment (base case)
         (name::Symbol, typ) = parse_typed_var(lhs)
-        # Create new name if variable is already bound
-        if haskey(bindings, name) name = gensym(name) end
-        node = parse_julia_expr!(stmts, bindings, name, rhs, typ)
+        # Generate new node name if name is already bound
+        node_name = haskey(bindings, name) ? gensym(name) : name
+        node = parse_julia_expr!(stmts, bindings, node_name, rhs, typ)
+        # Old bindings are overwritten with new nodes
         bindings[name] = node
     end
     # Return name of node to be processed by parent expressions

--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -102,7 +102,7 @@ macro param(expr_or_symbol)
     elseif expr_or_symbol.head == :(::)
         name = expr_or_symbol.args[1]
     else
-        error("Syntax in error in @static at $(expr_or_symbol)")
+        error("Syntax in error in @param at $(expr_or_symbol)")
     end
     Expr(:(=), esc(name), Expr(:call, :read_param, esc(state), QuoteNode(name)))
 end

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -103,7 +103,6 @@ params = ir.arg_nodes[2]
 
 # is_outlier
 is_outlier = ir.choice_nodes[1]
-# @test is_outlier.name == :is_outlier
 @test is_outlier.addr == :z
 @test is_outlier.typ == QuoteNode(Bool)
 @test is_outlier.dist == bernoulli
@@ -121,7 +120,6 @@ in2 = std.inputs[2]
 
 # y
 y = ir.choice_nodes[2]
-# @test y.name == :y
 @test y.addr == :y
 @test y.typ == QuoteNode(Float64)
 @test y.dist == normal
@@ -163,7 +161,6 @@ xs = ir.arg_nodes[1]
 
 # inlier_std
 inlier_std = ir.choice_nodes[1]
-# @test inlier_std.name == :inlier_std
 @test inlier_std.addr == :inlier_std
 @test inlier_std.typ == QuoteNode(Float64)
 @test inlier_std.dist == gamma
@@ -171,7 +168,6 @@ inlier_std = ir.choice_nodes[1]
 
 # outlier_std
 outlier_std = ir.choice_nodes[2]
-# @test outlier_std.name == :outlier_std
 @test outlier_std.addr == :outlier_std
 @test outlier_std.typ == QuoteNode(Float64)
 @test outlier_std.dist == gamma
@@ -179,7 +175,6 @@ outlier_std = ir.choice_nodes[2]
 
 # slope
 slope = ir.choice_nodes[3]
-# @test slope.name == :slope
 @test slope.addr == :slope
 @test slope.typ == QuoteNode(Float64)
 @test slope.dist == normal
@@ -187,7 +182,6 @@ slope = ir.choice_nodes[3]
 
 # intercept
 intercept = ir.choice_nodes[4]
-# @test intercept.name == :intercept
 @test intercept.addr == :intercept
 @test intercept.typ == QuoteNode(Float64)
 @test intercept.dist == normal
@@ -195,7 +189,6 @@ intercept = ir.choice_nodes[4]
 
 # data
 ys = ir.call_nodes[1]
-# @test ys.name == :ys
 @test ys.addr == :data
 @test ys.typ == QuoteNode(PersistentVector{Float64})
 @test ys.generative_function == data_fn

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -72,6 +72,12 @@ function get_node_by_name(ir, name::Symbol)
     nodes[1]
 end
 
+function get_node_by_addr(ir, addr::Symbol)
+    nodes = filter(n -> hasfield(typeof(n), :addr) && (n.addr==addr), ir.nodes)
+    @assert length(nodes) == 1
+    nodes[1]
+end
+
 @testset "check IR" begin
 
 #####################
@@ -97,7 +103,7 @@ params = ir.arg_nodes[2]
 
 # is_outlier
 is_outlier = ir.choice_nodes[1]
-@test is_outlier.name == :is_outlier
+# @test is_outlier.name == :is_outlier
 @test is_outlier.addr == :z
 @test is_outlier.typ == QuoteNode(Bool)
 @test is_outlier.dist == bernoulli
@@ -115,7 +121,7 @@ in2 = std.inputs[2]
 
 # y
 y = ir.choice_nodes[2]
-@test y.name == :y
+# @test y.name == :y
 @test y.addr == :y
 @test y.typ == QuoteNode(Float64)
 @test y.dist == normal
@@ -157,7 +163,7 @@ xs = ir.arg_nodes[1]
 
 # inlier_std
 inlier_std = ir.choice_nodes[1]
-@test inlier_std.name == :inlier_std
+# @test inlier_std.name == :inlier_std
 @test inlier_std.addr == :inlier_std
 @test inlier_std.typ == QuoteNode(Float64)
 @test inlier_std.dist == gamma
@@ -165,7 +171,7 @@ inlier_std = ir.choice_nodes[1]
 
 # outlier_std
 outlier_std = ir.choice_nodes[2]
-@test outlier_std.name == :outlier_std
+# @test outlier_std.name == :outlier_std
 @test outlier_std.addr == :outlier_std
 @test outlier_std.typ == QuoteNode(Float64)
 @test outlier_std.dist == gamma
@@ -173,7 +179,7 @@ outlier_std = ir.choice_nodes[2]
 
 # slope
 slope = ir.choice_nodes[3]
-@test slope.name == :slope
+# @test slope.name == :slope
 @test slope.addr == :slope
 @test slope.typ == QuoteNode(Float64)
 @test slope.dist == normal
@@ -181,7 +187,7 @@ slope = ir.choice_nodes[3]
 
 # intercept
 intercept = ir.choice_nodes[4]
-@test intercept.name == :intercept
+# @test intercept.name == :intercept
 @test intercept.addr == :intercept
 @test intercept.typ == QuoteNode(Float64)
 @test intercept.dist == normal
@@ -189,7 +195,7 @@ intercept = ir.choice_nodes[4]
 
 # data
 ys = ir.call_nodes[1]
-@test ys.name == :ys
+# @test ys.name == :ys
 @test ys.addr == :data
 @test ys.typ == QuoteNode(PersistentVector{Float64})
 @test ys.generative_function == data_fn
@@ -232,7 +238,7 @@ end
 # at_choice_example_1
 ir = Gen.get_ir(typeof(at_choice_example_1))
 i = get_node_by_name(ir, :i)
-ret = get_node_by_name(ir, :ret)
+ret = get_node_by_addr(ir, :x)
 @test isa(ret, Gen.GenerativeFunctionCallNode)
 @test ret.addr == :x
 @test length(ret.inputs) == 2
@@ -245,7 +251,7 @@ at = ret.generative_function
 # at_choice_example_2
 ir = Gen.get_ir(typeof(at_choice_example_2))
 i = get_node_by_name(ir, :i)
-ret = get_node_by_name(ir, :ret)
+ret = get_node_by_addr(ir, :x)
 @test isa(ret, Gen.GenerativeFunctionCallNode)
 @test ret.addr == :x
 @test length(ret.inputs) == 3
@@ -265,7 +271,7 @@ end
 # at_call_example_1
 ir = Gen.get_ir(typeof(at_call_example_1))
 i = get_node_by_name(ir, :i)
-ret = get_node_by_name(ir, :ret)
+ret = get_node_by_addr(ir, :x)
 @test isa(ret, Gen.GenerativeFunctionCallNode)
 @test ret.addr == :x
 @test length(ret.inputs) == 2
@@ -278,7 +284,7 @@ at = ret.generative_function
 #at_call_example_2
 ir = Gen.get_ir(typeof(at_call_example_2))
 i = get_node_by_name(ir, :i)
-ret = get_node_by_name(ir, :ret)
+ret = get_node_by_addr(ir, :x)
 @test isa(ret, Gen.GenerativeFunctionCallNode)
 @test ret.addr == :x
 @test length(ret.inputs) == 3


### PR DESCRIPTION
Addresses #90 and parts of #213. Opening this pull request for purposes of discussion and collaboration -- I don't think this is quite ready to be merged yet.

With the changes in this PR,  the static modeling language can now:
- Handle expressions that include multiple `@trace` calls on the right-hand-side:
```julia
@gen (static) function circle(r, t, std)
    pt = (@trace(normal(r*cos(t), std), :x), @trace(normal(r*sin(t), std), :y))
    return pt
end
@test circle(1, 0, 0) == (1, 0)
```

- Support re-assignment by relaxing the static single assignment restriction:
```julia
@gen (static) function foo(x)
    x = x + 1
    return x
end
@test foo(0) == 1
```

- Support tuple assignments:
```julia
@gen (static) function foo(params::Tuple)
    p, (mu1, sigma1), (mu2, sigma2) = params
    mu, sigma = @trace(bernoulli(p), :x) ? (mu1, sigma1) : (mu2, sigma2)
    return @trace(normal(mu, sigma), :y)
end
@test foo((1, (1, 0), (0, 0)) == 1
```
- Return arbitrary purely functional Julia expressions (including those with `@trace` calls)
- Catch and throw errors at parse time for a number of unsupported constructs (e.g. `@trace` calls which are non-addressed, argument splatting within `@trace` calls).

Most of these changes were implemented be refactoring the code to process ASTs bottom-up using `MacroTools.postwalk`, instead of the previous top-down approach. This allows us to match all `@trace` calls that are nested in other expressions and add a node to the Static IR for each of them. The `@trace` calls are then replaced by fresh variable names which are bound to those nodes*.

(*This changes the naming convention for Static IR nodes -- `@trace` nodes were previously named according to the variables they were assigned to, but now are named according to their addresses.)

In order to support more of the syntax extensions suggested in #213 (e.g. for loops and let expressions), it seems like the bottom-up parsing approach used in this PR will be insufficient, because the meaning and variable scope of (for e.g.) an `@trace` call in a for-loop is context-dependent. One possible approach to addressing this is to do an initial top-down pass (i.e. `MacroTools.prewalk`) through the AST as a preprocessing step.

For example, the top-down pass could rewrite for-loops with trace calls using some specialized syntax, which can then be matched and handled appropriately during the bottom-up pass. Or perhaps some other way of passing contextual information downwards could be devised. It'd be great to have some thoughts and ideas on how best to do this!