### PR TITLE
Slight fix in noise-tracking for Map and Unfold

### DIFF
--- a/src/modeling_library/map/update.jl
+++ b/src/modeling_library/map/update.jl
@@ -33,7 +33,7 @@ function process_retained!(gen_fn::Map{T,U}, args::Tuple,
     state.weight += weight
     set_submap!(state.discard, key, discard)
     state.score += (get_score(subtrace) - get_score(prev_subtrace))
-    state.noise += (project(subtrace, EmptySelection()) - project(subtrace, EmptySelection()))
+    state.noise += (project(subtrace, EmptySelection()) - project(prev_subtrace, EmptySelection()))
     state.subtraces = assoc(state.subtraces, key, subtrace)
     retval = get_retval(subtrace)
     state.retval = assoc(state.retval, key, retval)

--- a/src/modeling_library/unfold/update.jl
+++ b/src/modeling_library/unfold/update.jl
@@ -36,7 +36,7 @@ function process_retained!(gen_fn::Unfold{T,U}, params::Tuple,
     state.weight += weight
     set_submap!(state.discard, key, discard)
     state.score += (get_score(subtrace) - get_score(prev_subtrace))
-    state.noise += (project(subtrace, EmptySelection()) - project(subtrace, EmptySelection()))
+    state.noise += (project(subtrace, EmptySelection()) - project(prev_subtrace, EmptySelection()))
     state.subtraces = assoc(state.subtraces, key, subtrace)
     new_state = get_retval(subtrace)
     state.retval = assoc(state.retval, key, new_state)


### PR DESCRIPTION
In both combinators, the code currently reads:

```
state.noise += (project(subtrace, EmptySelection()) - project(subtrace, EmptySelection()))
```

I believe we should be subtracting the noise for the _previous_ subtrace:

```
state.noise += (project(subtrace, EmptySelection()) - project(prev_subtrace, EmptySelection()))
```