### PR TITLE
fast `project` on empty selections for `VectorTrace`, static IR traces

### DIFF
--- a/src/modeling_library/vector.jl
+++ b/src/modeling_library/vector.jl
@@ -70,6 +70,7 @@ function project(trace::VectorTrace, selection::Selection)
     end
     weight
 end
+project(trace::VectorTrace, ::EmptySelection) = trace.noise
 
 struct VectorTraceChoiceMap{GenFnType, T, U} <: ChoiceMap
     trace::VectorTrace{GenFnType, T, U}

--- a/src/static_ir/project.jl
+++ b/src/static_ir/project.jl
@@ -55,7 +55,13 @@ function codegen_project(trace_type::Type, selection_type::Type)
 end
 
 push!(generated_functions, quote
+
 @generated function $(Expr(:(.), Gen, QuoteNode(:project)))(trace::T, selection::$(QuoteNode(Selection))) where {T <: $(QuoteNode(StaticIRTrace))}
     $(QuoteNode(codegen_project))(trace, selection)
 end
+
+function $(Expr(:(.), Gen, QuoteNode(:project)))(trace::T, selection::$(QuoteNode(EmptySelection))) where {T <: $(QuoteNode(StaticIRTrace))}
+    trace.$total_noise_fieldname
+end
+
 end)


### PR DESCRIPTION
Resolves #218 by improving `project` performance on `EmptySelection` for `VectorTrace` and Static IR traces.

In addition to passing all the tests in `runtests.jl`, I ran some quick performance tests to confirm we get an improvement.  On a small static trace, `project` for the empty selection were consistently `@time`d as taking between `0.000010` and `0.000012` seconds using the old implementation, whereas for the new implementation they are between `0.000006` and `0.000008`.  (This is a pretty small difference, but it is consistent, and there was only one address in my static trace in my example, so my sense is this is probably about right.)
For a 1000 element `Map` trace, `project` for empty selection take around `0.000321` seconds for the old implementation and `0.000006` for the new version.