### PR TITLE
Fix the call to `@trace` in tilde desugaring

### DIFF
--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -73,12 +73,12 @@ end
 function desugar_tildes(expr)
     MacroTools.postwalk(expr) do e
         if MacroTools.@capture(e, {*} ~ rhs_)
-            :(@trace($rhs))
+            :(trace($rhs))
         elseif MacroTools.@capture(e, {addr_} ~ rhs_)
-            :(@trace($rhs, $(addr)))
+            :(trace($rhs, $(addr)))
         elseif MacroTools.@capture(e, lhs_ ~ rhs_)
             addr_expr = address_from_expression(lhs)
-            :($lhs = @trace($rhs, $(addr_expr)))
+            :($lhs = trace($rhs, $(addr_expr)))
         else
             e
         end

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -135,9 +135,13 @@ function insert_quoted_exprs(expr, quoted_exprs)
 end
 
 function preprocess_body(expr, __module__)
+    # Protect quoted expressions from pre-processing by extracting them
     expr, quoted_exprs = extract_quoted_exprs(expr)
+    # Desugar tilde calls to globally referenced @trace calls
     expr = desugar_tildes(expr)
+    # Also resolve Gen macros to GlobalRefs for consistent downstream parsing 
     expr = resolve_gen_macros(expr, __module__)
+    # Reinsert quoted expressions after pre-processing
     expr = insert_quoted_exprs(expr, quoted_exprs)
     return expr
 end

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -98,7 +98,8 @@ function resolve_gen_macros(expr, __module__)
             line_num = e.args[2]
             Expr(:macrocall, macro_ref, line_num, args...)
         elseif (MacroTools.@capture(e, @m_(args__)) &&
-                m in DSL_MACROS && __module__ == @__MODULE__)
+                m in DSL_MACROS && isdefined(__module__, m) &&
+                getfield(__module__, m) == getfield(@__MODULE__, m))
             macro_ref = GlobalRef(@__MODULE__, m)
             line_num = e.args[2]
             Expr(:macrocall, macro_ref, line_num, args...)

--- a/test/tilde_sugar.jl
+++ b/test/tilde_sugar.jl
@@ -1,9 +1,10 @@
 using Gen
 import MacroTools
 
-normalize(ex) = MacroTools.prewalk(MacroTools.rmlines, ex)
+@testset "tilde syntax" begin
 
-
+normalize(ex) =
+    MacroTools.prewalk(MacroTools.rmlines, Gen.resolve_gen_macros(ex, Main))
 
 # dynamic
 @testset "tilde syntax smoke test (dynamic)" begin
@@ -73,17 +74,32 @@ end
 
 
 @testset "tilde syntax desugars as expected (static)" begin
-expected = normalize(:(
-@gen (static) function foo()
-    x = @trace(normal(0, 1), :x)
-    y = @trace(normal(0, 1), :y)
-end))
+    expected = normalize(:(
+    @gen (static) function foo()
+        x = @trace(normal(0, 1), :x)
+        y = @trace(normal(0, 1), :y)
+    end))
 
-actual = normalize(Gen.desugar_tildes(:(
-@gen (static) function foo()
-    x ~ normal(0, 1)
-    y = ({:y} ~ normal(0, 1))
-end)))
+    actual = normalize(Gen.desugar_tildes(:(
+    @gen (static) function foo()
+        x ~ normal(0, 1)
+        y = ({:y} ~ normal(0, 1))
+    end)))
 
-@test actual == expected
+    @test actual == expected
+end
+
+@testset "tilde syntax preserved in quoted expressions" begin
+    @gen function tilde_expr()
+        return :(x ~ normal(0, 1))
+    end
+    @test tilde_expr() == :(x ~ normal(0, 1))
+
+    @gen (static) function tilde_expr()
+        return :(x ~ normal(0, 1))
+    end
+    Gen.load_generated_functions()
+    @test tilde_expr() == :(x ~ normal(0, 1))
+end
+
 end


### PR DESCRIPTION
Fixes https://github.com/probcomp/Gen/issues/222.

Quoting https://github.com/probcomp/Gen/issues/222#issuecomment-606780545:

> I think what should be happening is that `trace` (as a function on ASTs) should be called at macro expansion time, from within Gen's internals. Instead, the desugarer was punting the `@trace`ing to the caller, which actually worked if the caller happened to have `@trace` in their namespace, but was not the intended logic.

## Tested

The minimal example in https://github.com/probcomp/Gen/issues/222#issue-591297488 now works.