### PR TITLE
Move pretty-printing logic to "text/plain" MIME type

### DIFF
--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -973,7 +973,7 @@ function Base.length(cv::ChoiceMapNestedView)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", c::ChoiceMapNestedView)
-  Base.show(io, MIME"text/plain"(), c.choice_map)
+    Base.show(io, MIME"text/plain"(), c.choice_map)
 end
 
 nested_view(c::ChoiceMap) = ChoiceMapNestedView(c)

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -92,7 +92,7 @@ end
     get_submap(submap, rest)
 end
 
-function _print(io::IO, choices::ChoiceMap, pre, vert_bars::Tuple)
+function _show_pretty(io::IO, choices::ChoiceMap, pre, vert_bars::Tuple)
     VERT = '\u2502'
     PLUS = '\u251C'
     HORZ = '\u2500'
@@ -115,20 +115,20 @@ function _print(io::IO, choices::ChoiceMap, pre, vert_bars::Tuple)
     n = length(key_and_values) + length(key_and_submaps)
     cur = 1
     for (key, value) in key_and_values
-        print(io, indent_vert_str)
-        print(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key)) : $value\n")
+        show(io, indent_vert_str)
+        show(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key)) : $value\n")
         cur += 1
     end
     for (key, submap) in key_and_submaps
-        print(io, indent_vert_str)
-        print(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key))\n")
-        _print(io, submap, pre + 4, cur == n ? (vert_bars...,) : (vert_bars..., pre+1))
+        show(io, indent_vert_str)
+        show(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key))\n")
+        _show_pretty(io, submap, pre + 4, cur == n ? (vert_bars...,) : (vert_bars..., pre+1))
         cur += 1
     end
 end
 
-function Base.print(io::IO, choices::ChoiceMap)
-    _print(io, choices, 0, ())
+function Base.show(io::IO, ::MIME"text/plain", choices::ChoiceMap)
+    _show_pretty(io, choices, 0, ())
 end
 
 # assignments that have static address schemas should also support faster
@@ -970,7 +970,9 @@ function Base.length(cv::ChoiceMapNestedView)
     get_submaps_shallow(cv.choice_map) |> collect |> length)
 end
 
-Base.print(io::IO, c::ChoiceMapNestedView) = Base.print(io, c.choice_map)
+function Base.show(io::IO, ::MIME"text/plain", c::ChoiceMapNestedView)
+  Base.show(io, MIME"text/plain"(), c.choice_map)
+end
 
 nested_view(c::ChoiceMap) = ChoiceMapNestedView(c)
 

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -115,13 +115,15 @@ function _show_pretty(io::IO, choices::ChoiceMap, pre, vert_bars::Tuple)
     n = length(key_and_values) + length(key_and_submaps)
     cur = 1
     for (key, value) in key_and_values
-        show(io, indent_vert_str)
-        show(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key)) : $value\n")
+        # For strings, `print` is what we want; `Base.show` includes quote marks.
+        # https://docs.julialang.org/en/v1/base/io-network/#Base.print
+        print(io, indent_vert_str)
+        print(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key)) : $value\n")
         cur += 1
     end
     for (key, submap) in key_and_submaps
-        show(io, indent_vert_str)
-        show(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key))\n")
+        print(io, indent_vert_str)
+        print(io, (cur == n ? indent_last_str : indent_str) * "$(repr(key))\n")
         _show_pretty(io, submap, pre + 4, cur == n ? (vert_bars...,) : (vert_bars..., pre+1))
         cur += 1
     end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -90,21 +90,17 @@ function metropolis_hastings(
     if check
         (trace_rt, fwd_choices_rt, weight_rt) = involution(new_trace, bwd_choices, bwd_ret, proposal_args)
         if !isapprox(fwd_choices_rt, fwd_choices)
-            println("fwd_choices:")
-            println(fwd_choices)
-            println("fwd_choices_rt:")
-            println(fwd_choices_rt)
+            @error "fwd_choices: $(sprint(show, "text/plain", fwd_choices))"
+            @error "fwd_choices_rt: $(sprint(show, "text/plain", fwd_choices_rt))"
             error("Involution round trip check failed")
         end
         if !isapprox(get_choices(trace), get_choices(trace_rt))
-            println("get_choices(trace):")
-            println(get_choices(trace))
-            println("get_choices(trace_rt):")
-            println(get_choices(trace_rt))
+            @error "get_choices(trace): $(sprint(show, "text/plain", get_choices(trace)))"
+            @error "get_choices(trace_rt): $(sprint(show, "text/plain", get_choices(trace_rt)))"
             error("Involution round trip check failed")
         end
         if !isapprox(weight, -weight_rt)
-            println("weight: $weight, -weight_rt: $(-weight_rt)")
+            @error "weight: $weight, -weight_rt: $(-weight_rt)"
             error("Involution round trip check failed")
         end
     end


### PR DESCRIPTION
Per https://github.com/probcomp/Gen/issues/227.

## Tested

The following REPL session:
```julia
julia> import Gen

julia> c = Gen.choicemap((:a, 1), (:b => :c, 2), (:b => :d, 3))
# │
# ├── :a : 1
# │
# └── :b
#     │
#     ├── :d : 3
#     │
#     └── :c : 2
# 
#

julia> print(c)
# Gen.DynamicChoiceMap(Dict{Any,Any}(:a=>1), Dict{Any,Any}(:b=>DynamicChoiceMap(Dict{Any,Any}(:d=>3,:c=>2), Dict{Any,Any}())))

julia> display(c)
# │
# ├── :a : 1
# │
# └── :b
#     │
#     ├── :d : 3
#     │
#     └── :c : 2
# 
# 

julia> string(c)
# "Gen.DynamicChoiceMap(Dict{Any,Any}(:a=>1), Dict{Any,Any}(:b=>DynamicChoiceMap(Dict{Any,Any}(:d=>3,:c=>2), Dict{Any,Any}())))"

julia> sprint(show, "text/plain", c)
# "│\n├── :a : 1\n│\n└── :b\n    │\n    ├── :d : 3\n    │\n    └── :c : 2\n"

julia> Gen.nested_view(c)
# │
# ├── :a : 1
# │
# └── :b
#     │
#     ├── :d : 3
#     │
#     └── :c : 2
# 
# 

julia> string(Gen.nested_view(c))
# "Gen.ChoiceMapNestedView(Gen.DynamicChoiceMap(Dict{Any,Any}(:a => 1), Dict{Any,Any}(:b => Gen.DynamicChoiceMap(Dict{Any,Any}(:d => 3,:c => 2), Dict{Any,Any}()))))"
```