### PR TITLE
Clarify that `particle_filter_step!` falls back to the particle's previous trace for choices that exist there

### DIFF
--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -117,8 +117,9 @@ model's internal proposal is used for proposing new latent state.  That is, for
 each particle,
 
 * The proposal function `proposal` is evaluated with arguments `Tuple(t_old,
-  proposal_args...)`, and produces a trace (call it `proposal_trace`); and
-* The old trace (call it `t_old`) is replaced by a new trace (call it `t_new`).
+  proposal_args...)` (where `t_old` is the old model trace), and produces its
+  own trace (call it `proposal_trace`); and
+* The old model trace is replaced by a new model trace (call it `t_new`).
 
 The choicemap of `t_new` satisfies the following conditions:
 

--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -111,7 +111,17 @@ end
     particle_filter_step!(state::ParticleFilterState, new_args::Tuple, argdiffs,
         observations::ChoiceMap, proposal::GenerativeFunction, proposal_args::Tuple)
 
-Perform a particle filter update, where the model arguments are adjusted, new observations are added, and some combination of a custom proposal and the model's internal proposal is used for proposing new latent state (whatever is not proposed from the custom proposal will be proposed using the model's internal proposal).
+Perform a particle filter update, where the model arguments are adjusted, new
+observations are added, and some combination of a custom proposal and the
+model's internal proposal is used for proposing new latent state.  That is, for
+each particle, the value of a random choice at address `a` in the new trace for
+that particle is chosen by the following rule:
+
+* If the proposal's choicemap has a random choice at address `a`, use that
+  value.
+* Otherwise, if the choicemap of the particle's previous trace has a random
+  choice at address `a`, use that value.
+* Otherwise, sample the value from the model's internal proposal.
 """
 function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, argdiffs::Tuple,
         observations::ChoiceMap, proposal::GenerativeFunction, proposal_args::Tuple) where {U}

--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -116,11 +116,10 @@ observations are added, and some combination of a custom proposal and the
 model's internal proposal is used for proposing new latent state.  That is, for
 each particle, the value of a random choice at address `a` in the new trace for
 that particle is chosen by the following rule:
-
+* The particle's previous trace must not have a random choice at address `a`:
+  overwriting old state is not allowed.
 * If the proposal's choicemap has a random choice at address `a`, use that
   value.
-* Otherwise, if the choicemap of the particle's previous trace has a random
-  choice at address `a`, use that value.
 * Otherwise, sample the value from the model's internal proposal.
 """
 function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, argdiffs::Tuple,

--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -114,13 +114,26 @@ end
 Perform a particle filter update, where the model arguments are adjusted, new
 observations are added, and some combination of a custom proposal and the
 model's internal proposal is used for proposing new latent state.  That is, for
-each particle, the value of a random choice at address `a` in the new trace for
-that particle is chosen by the following rule:
-* The particle's previous trace must not have a random choice at address `a`:
-  overwriting old state is not allowed.
-* If the proposal's choicemap has a random choice at address `a`, use that
-  value.
-* Otherwise, sample the value from the model's internal proposal.
+each particle,
+
+* The proposal function `proposal` is evaluated with arguments `Tuple(t_old,
+  proposal_args...)`, and produces a trace (call it `proposal_trace`); and
+* The old trace (call it `t_old`) is replaced by a new trace (call it `t_new`).
+
+The choicemap of `t_new` satisfies the following conditions:
+
+1. `get_choices(t_old)` is a subset of `get_choices(t_new)`;
+2. `observations` is a subset of `get_choices(t_new)`;
+3. `get_choices(proposal_trace)` is a subset of `get_choices(t_new)`.
+
+Here, when we say one choicemap `a` is a "subset" of another choicemap `b`, we
+mean that all keys that occur in `a` also occur in `b`, and the values at those
+addresses are equal.
+
+It is an error if no trace `t_new` satisfying the above conditions exists in
+the support of the model (with the new arguments). If such a trace exists, then
+the random choices not determined by the above requirements are sampled using
+the internal proposal.
 """
 function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, argdiffs::Tuple,
         observations::ChoiceMap, proposal::GenerativeFunction, proposal_args::Tuple) where {U}


### PR DESCRIPTION
# Summary

Documentation-only change, requesting confirmation that the proposed doc is accurate