### PR TITLE
Deprecate load_generated_functions() in favor of @load_generated_functions.

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -451,22 +451,34 @@ can instead be implemented as:
 ```
 
 ### Loading generated functions
-Before a function with a static annotation can be used, the [`load_generated_functions`](@ref) method must be called:
+Before a function with a static annotation can be used, the [`@load_generated_functions`](@ref) macro must be called:
 ```@docs
-load_generated_functions
+@load_generated_functions
 ```
 Typically, one call to this function, at the top level of a script, separates the definition of generative functions from the execution of inference code, e.g.:
 ```julia
-using Gen: load_generated_functions
+using Gen: @load_generated_functions
 
 # define generative functions and inference code
 ..
 
 # allow static generative functions defined above to be used
-load_generated_functions()
+@load_generated_functions
 
 # run inference code
 ..
+```
+
+When static generative functions are defined in a Julia module, [`@load_generated_functions`](@ref) should be called after all static functions are defined:
+
+```julia
+module MyModule
+using Gen
+# Include code that defines static generative functions
+include("my_static_gen_functions.jl")
+# Load generated functions defined in this module
+Gen.@load_generated_functions
+end
 ```
 
 ### Performance tips

--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -463,7 +463,7 @@ using Gen: @load_generated_functions
 ..
 
 # allow static generative functions defined above to be used
-@load_generated_functions
+@load_generated_functions()
 
 # run inference code
 ..
@@ -477,11 +477,17 @@ using Gen
 # Include code that defines static generative functions
 include("my_static_gen_functions.jl")
 # Load generated functions defined in this module
-@load_generated_functions
+@load_generated_functions()
 end
 ```
 
-Any script that imports or uses `MyModule` will then no longer need to call `@load_generated_functions`, unless they also define their own static generative functions.
+Any script that imports or uses `MyModule` will then no longer need to call `@load_generated_functions` in order to use the static generative functions defined in that module:
+
+```julia
+using Gen
+using MyModule: my_static_gen_fn
+trace = simulate(my_static_gen_fn, ())
+```
 
 ### Performance tips
 For better performance when the arguments are simple data types like `Float64`, annotate the arguments with the concrete type.

--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -477,9 +477,11 @@ using Gen
 # Include code that defines static generative functions
 include("my_static_gen_functions.jl")
 # Load generated functions defined in this module
-Gen.@load_generated_functions
+@load_generated_functions
 end
 ```
+
+Any script that imports or uses `MyModule` will then no longer need to call `@load_generated_functions`, unless they also define their own static generative functions.
 
 ### Performance tips
 For better performance when the arguments are simple data types like `Float64`, annotate the arguments with the concrete type.

--- a/src/Gen.jl
+++ b/src/Gen.jl
@@ -5,17 +5,30 @@ module Gen
 const generated_functions = []
 
 """
-    load_generated_functions()
+    load_generated_functions(__module__=Main)
 
-Permit use of generative functions written in the static modeling language up to this point.
+Permit use of generative functions written in the static modeling language up
+to this point. Functions are loaded into Main by default.
 """
-function load_generated_functions()
+function load_generated_functions(__module__::Module=Main)
     for function_defn in generated_functions
-    Core.eval(Main, function_defn)
+        Core.eval(__module__, function_defn)
     end
 end
 
-export load_generated_functions
+"""
+    @load_generated_functions
+
+Permit use of generative functions written in the static modeling language up
+to this point. Functions are loaded into the calling module.
+"""
+macro load_generated_functions()
+    for function_defn in generated_functions
+        Core.eval(__module__, function_defn)
+    end
+end
+
+export load_generated_functions, @load_generated_functions
 
 # built-in extensions to the reverse mode AD
 include("backprop.jl")

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -64,6 +64,25 @@ end
     ret = @trace(foo(mu), :x => i => :y)
 end
 
+# Modules to test load_generated_functions
+module MyModuleA
+using Gen
+@gen (static) function foo(mu)
+    y = @trace(normal(mu, 1), :y)
+    return y
+end
+load_generated_functions(@__MODULE__)
+end
+
+module MyModuleB
+using Gen
+@gen (static) function foo(mu)
+    y = @trace(normal(mu, 1), :y)
+    return y
+end
+@load_generated_functions
+end
+
 @testset "static DSL" begin
 
 function get_node_by_name(ir, name::Symbol)
@@ -533,6 +552,18 @@ end
 load_generated_functions()
 
 tr, w = generate(foo, (0,), choicemap(:y => 1))
+@test get_retval(tr) == 1
+@test isapprox(w, logpdf(normal, 1, 0, 1))
+
+end
+
+@testset "module-defined static functions" begin
+
+tr, w = generate(MyModuleA.foo, (0,), choicemap(:y => 1))
+@test get_retval(tr) == 1
+@test isapprox(w, logpdf(normal, 1, 0, 1))
+
+tr, w = generate(MyModuleB.foo, (0,), choicemap(:y => 1))
 @test get_retval(tr) == 1
 @test isapprox(w, logpdf(normal, 1, 0, 1))
 


### PR DESCRIPTION
Addresses #209, but preserves backwards compatibility for `load_generated_functions()`.

The main motivation for switching to a macro call is so that users don't have to call `load_generated_functions()` at the top of their script when they're using module-defined static generative functions. Instead, they can do:

```julia
module MyModule
using Gen
export foo
@gen (static) function foo(mu)
    y = @trace(normal(mu, 0), :y)
    return y
end
Gen.@load_generated_functions
end
```

And then any script that uses MyModule works without needing to call `load_generated_functions()` at the top:
```
using MyModule
@assert foo(5) == 5
```

As noted in #209 , we can't simply call `load_generated_functions()` within `MyModule` -- this is because the `Core.eval` call in `load_generated_functions` evaluates the generated functions into `Main`, but when `MyModule` is part of a Julia package, eval-ing into `Main` like that doesn't work. 

`@load_generated_functions` fixes this by evaluating within `__module__` instead. For backwards compatibility and some additional flexibility, `load_generated_functions` still works as before, and also accepts an optional module argument (so, for example, `load_generated_functions(@__MODULE__)` within `MyModule.jl` would achieve the same effect as `@load_generated_functions`). But for most intents and purposes, people should probably use `@load_generated_functions` both within scripts and modules. The documentation has been updated accordingly.