### PR TITLE
Remember observations in PF state + minor PF interface extensions.

### DIFF
--- a/docs/src/ref/pf.md
+++ b/docs/src/ref/pf.md
@@ -5,6 +5,9 @@ particle_filter_step!
 maybe_resample!
 log_ml_estimate
 get_traces
+get_observations
 get_log_weights
+get_log_norm_weights
+get_effective_sample_size
 sample_unweighted_traces
 ```

--- a/test/inference/particle_filter.jl
+++ b/test/inference/particle_filter.jl
@@ -6,13 +6,13 @@ function hmm_forward_alg(prior::Vector{Float64},
     for i=2:length(emissions)
 
         # p(z_{i-1} , y_{i-1} | y_{1:i-2}) for each z_{i-1}
-        prev_posterior = alpha .* emission_dists[emissions[i-1], :] 
+        prev_posterior = alpha .* emission_dists[emissions[i-1], :]
 
         # p(y_{i-1} | y_{1:i-2})
-        denom = sum(prev_posterior) 
+        denom = sum(prev_posterior)
 
         # p(z_{i-1} | y_{1:i-1})
-        prev_posterior = prev_posterior / denom 
+        prev_posterior = prev_posterior / denom
 
         # p(z_i | y_{1:i-1})
         alpha = transition_dists * prev_posterior
@@ -20,8 +20,8 @@ function hmm_forward_alg(prior::Vector{Float64},
         # p(y_{1:i-1})
         marg_lik *= denom
     end
-    prev_posterior = alpha .* emission_dists[emissions[end], :] 
-    denom = sum(prev_posterior) 
+    prev_posterior = alpha .* emission_dists[emissions[end], :]
+    denom = sum(prev_posterior)
     marg_lik *= denom
     marg_lik
 end
@@ -31,7 +31,7 @@ end
     # test the hmm_forward_alg on a hand-calculated example
     prior = [0.4, 0.6]
     emission_dists = [0.1 0.9; 0.7 0.3]'
-    transition_dists = [0.5 0.5; 0.2 0.8']
+    transition_dists = [0.5 0.5; 0.2 0.8]'
     obs = [2, 1]
     expected_marg_lik = 0.
     # z = [1, 1]
@@ -44,7 +44,7 @@ end
     expected_marg_lik += prior[2] * transition_dists[2, 2] * emission_dists[obs[1], 2] * emission_dists[obs[2], 2]
     actual_marg_lik = hmm_forward_alg(prior, emission_dists, transition_dists, obs)
     @test isapprox(actual_marg_lik, expected_marg_lik)
-    
+
 end
 
 @testset "particle filtering" begin
@@ -113,7 +113,7 @@ end
         init_proposal, init_proposal_args, num_particles)
 
     # do particle filter steps
-    
+
     @gen function step_proposal(prev_trace, T::Int, x::Float64)
         @assert T > 1
         choices = get_choices(prev_trace)
@@ -135,7 +135,7 @@ end
         particle_filter_step!(state, new_args, argdiffs, observations,
             step_proposal, proposal_args)
     end
-    
+
     # check log marginal likelihood estimate
     expected_log_ml = log(hmm_forward_alg(prior, emission_dists, transition_dists, obs_x))
     actual_log_ml_est = log_ml_estimate(state)
@@ -151,7 +151,7 @@ end
     # initialize the particle filter
     init_observations = choicemap((:x_init, obs_x[1]))
     state = initialize_particle_filter(model, (1,), init_observations, num_particles)
-    
+
     # do steps
     argdiffs = (UnknownChange(),) # the length may change
     for T=2:length(obs_x)


### PR DESCRIPTION
In some custom SMC code I'm currently writing, it's helpful to have access to the history of observations provided to the particle filter as a choicemap. In particular, I want to do a form of "importance resampling rejuvenation" when the effective sample size gets too small, where I throw out a bunch of old traces in the particle filter, and sample totally new traces using a proposal distribution. This requires conditioning on the observations provided so far, which are not currently stored separately from all the choices associated with each trace in the particle filter. 

I imagine there are other custom SMC extensions that would find this useful as well -- for example, data-driven MCMC proposals within a rejuvenation move.

This PR adds support for that by storing the initial observations during `initialize_particle_filter`, and then subsequently updating the state with new observations every time `particle_filter_step!` is called. 

I've also made a few minor extensions to the particle filter interface, which I think are helpful for users writing custom SMC code.