### PR TITLE
Bump Julia version in Travis to 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: julia
 julia:
-  - 1.3
+  - 1.4
 
 jobs:
   include:
@@ -11,7 +11,7 @@ jobs:
       script:
         - julia -e 'using Pkg; Pkg.build(); Pkg.test()'
     - stage: docs
-      julia: 1.3
+      julia: 1.4
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));


### PR DESCRIPTION
Fixes https://github.com/probcomp/Gen/issues/245.

## Tested

CI passes on https://github.com/Kenta426/Gen/commit/6333bb72764ccf3f486fdfedbca2da642012bf22 until an error in the pending code ([build](https://travis-ci.com/github/probcomp/Gen/jobs/322570995)); in particular, building and running Gen works.