### PR TITLE
Fix #253 (@dist dsl issue with `-`)

### DIFF
--- a/src/modeling_library/dist_dsl/dist_dsl.jl
+++ b/src/modeling_library/dist_dsl/dist_dsl.jl
@@ -183,7 +183,7 @@ Base.:-(b::DistWithArgs{T}, a::Real) where T <: Real = b + (-1 * a)
 Base.:-(b::DistWithArgs{T}, a::Arg) where T <: Real =
     DistWithArgs(TransformedDistribution{T, T}(b.base, 1, -, +, (x, a) -> (1.0, 1.0)), (a, b.arglist...))
 Base.:-(a::Real, b::DistWithArgs{T}) where T <: Real =
-    DistWithArgs(TransformedDistribution{T, T}(b.base, 1, x -> a - x, x -> a - x, x -> (-1.0,)), b.arglist)
+    DistWithArgs(TransformedDistribution{T, T}(b.base, 0, x -> a - x, x -> a - x, x -> (-1.0,)), b.arglist)
 Base.:-(a::Arg, b::DistWithArgs{T}) where T <: Real =
     DistWithArgs(TransformedDistribution{T, T}(b.base, 1, (x, a) -> a - x, (x, a) -> a - x, (x, a) -> (-1.0, 1.0)), (a, b.arglist...))
 

--- a/test/modeling_library/dist_dsl.jl
+++ b/test/modeling_library/dist_dsl.jl
@@ -23,7 +23,7 @@
   @test isapprox(logpdf(enum_cat, orange, [0.5, 0.5]), log(0.5))
   @test logpdf(enum_cat, orange, [1.0]) == -Inf
 
-  # Regression test for Issue #253
+  # Regression test for https://github.com/probcomp/Gen/issues/253
   @dist real_minus_uniform(a, b) = 1 - Gen.uniform(a, b)
   @test real_minus_uniform(1, 2) < 0
   @test logpdf(real_minus_uniform, -0.5, 1, 2) == 0.0

--- a/test/modeling_library/dist_dsl.jl
+++ b/test/modeling_library/dist_dsl.jl
@@ -22,6 +22,11 @@
   @test enum_cat([0., 1.]) == orange
   @test isapprox(logpdf(enum_cat, orange, [0.5, 0.5]), log(0.5))
   @test logpdf(enum_cat, orange, [1.0]) == -Inf
+
+  # Regression test for Issue #253
+  @dist real_minus_uniform(a, b) = 1 - Gen.uniform(a, b)
+  @test real_minus_uniform(1, 2) < 0
+  @test logpdf(real_minus_uniform, -0.5, 1, 2) == 0.0
 end
 
 # User-defined type for testing purposes


### PR DESCRIPTION
This one-character change fixes the bug @bzinberg found in the `@dist` DSL, where `x::Real - random_things` wasn't working. We needed to change the `n_args` argument of `TransformedDistribution` from `1` to `0`:  the transformation of subtracting a random variable from a constant does not change the number of arguments that the distribution has.