### PR TITLE
1 line bugfix for `get_submap` on static gen function choicemap which should return emptychoicemap

### DIFF
--- a/src/static_ir/trace.jl
+++ b/src/static_ir/trace.jl
@@ -25,6 +25,7 @@ end
 @inline function get_submap(choices::StaticIRTraceAssmt, key::Symbol)
     static_get_submap(choices, Val(key))
 end
+static_get_submap(::StaticIRTraceAssmt, ::Val) = EmptyChoiceMap()
 
 @inline get_value(choices::StaticIRTraceAssmt, addr::Pair) = _get_value(choices, addr)
 @inline has_value(choices::StaticIRTraceAssmt, addr::Pair) = _has_value(choices, addr)

--- a/test/static_dsl.jl
+++ b/test/static_dsl.jl
@@ -569,4 +569,26 @@ tr, w = generate(MyModuleB.foo, (0,), choicemap(:y => 1))
 
 end
 
+@testset "static gen function choicemaps" begin
+@gen (static) function bar2()
+    b ~ normal(0, 1)
+    return b
+end
+@gen (static) function bar1()
+    a ~ bar2()
+    x ~ normal(0, 1)
+    return x
+end
+Gen.load_generated_functions()
+tr = simulate(bar1, ())
+ch = get_choices(tr)
+@test has_value(ch, :x)
+@test !has_value(ch, :y)
+@test_throws KeyError get_submap(ch, :x)
+@test has_value(get_submap(ch, :a), :b)
+@test get_submap(ch, :y) == EmptyChoiceMap()
+@test length(get_values_shallow(ch)) == 1
+@test length(get_submaps_shallow(ch)) == 1
+end
+
 end # @testset "static DSL"


### PR DESCRIPTION
My understanding is that calling `get_submap(choicemap, :x)` should return an `EmptyChoiceMap` if `:x` does not store a value or submap in `choicemap`.  However, the choicemaps for the trace of a static DSL generative function throws an error if you try to `get_submap` for an address which is not present on the trace.

This PR adds a one-liner to make sure these sorts of `get_submap` calls return `EmptyChoiceMap`.  I also added a few quick tests to the static DSL test file for the choicemaps on these generative functions.