### PR TITLE
Fix static codegen scope

### DIFF
--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -112,7 +112,7 @@ end
 function extract_quoted_exprs(expr)
     quoted_exprs = []
     expr = MacroTools.prewalk(expr) do e
-        if MacroTools.@capture(e, :(quoted_))
+        if MacroTools.@capture(e, :(quoted_)) && !isa(quoted, Symbol)
             push!(quoted_exprs, e)
             Expr(:placeholder, length(quoted_exprs))
         else

--- a/src/static_ir/backprop.jl
+++ b/src/static_ir/backprop.jl
@@ -66,7 +66,7 @@ function back_pass!(back_marked, node::RandomChoiceNode)
         push!(back_marked, input_node)
     end
     # the value of every random choice is in back_marked, since it affects its logpdf
-    push!(back_marked, node) 
+    push!(back_marked, node)
 end
 
 function back_pass!(back_marked, node::GenerativeFunctionCallNode)
@@ -124,7 +124,7 @@ function fwd_codegen!(stmts, fwd_marked, back_marked, node::JuliaNode)
     else
 
         # regular forward execution.
-    
+
         # we need the value for initializing gradient to zero (to get the type
         # and e.g. shape), and for reference by other nodes during
         # back_codegen! we could be more selective about which JuliaNodes need
@@ -141,7 +141,7 @@ function fwd_codegen!(stmts, fwd_marked, back_marked, node::RandomChoiceNode)
 
     # every random choice is in back_marked, since it affects it logpdf, but
     # also possibly due to other downstream usage of the value
-    @assert node in back_marked 
+    @assert node in back_marked
 
     if node in fwd_marked
         # the only way we are fwd_marked is if this choice was selected
@@ -245,7 +245,7 @@ end
 function back_codegen!(stmts, ir, selected_calls, fwd_marked, back_marked,
                        node::RandomChoiceNode, ::BackpropTraceMode)
     logpdf_grad = gensym("logpdf_grad")
- 
+
     # backpropagate to the inputs
     back_codegen_random_choice_to_inputs!(stmts, ir, fwd_marked, back_marked, node, logpdf_grad)
 
@@ -280,7 +280,7 @@ function back_codegen!(stmts, ir, selected_calls, fwd_marked, back_marked,
         subtrace_fieldname = get_subtrace_fieldname(node)
         call_selection = gensym("call_selection")
         if node in selected_calls
-            push!(stmts, :($call_selection = $qn_static_getindex(selection, $(QuoteNode(Val(node.addr))))))
+            push!(stmts, :($call_selection = $(GlobalRef(Gen, :static_getindex))(selection, $(QuoteNode(Val(node.addr))))))
         else
             push!(stmts, :($call_selection = EmptySelection()))
         end
@@ -432,7 +432,7 @@ function codegen_choice_gradients(trace_type::Type{T}, selection_type::Type,
     # assemble value_trie and gradient_trie
     value_trie = gensym("value_trie")
     gradient_trie = gensym("gradient_trie")
-    push!(stmts, generate_value_gradient_trie(selected_choices, selected_calls, 
+    push!(stmts, generate_value_gradient_trie(selected_choices, selected_calls,
         value_trie, gradient_trie))
 
     # gradients with respect to inputs
@@ -441,7 +441,7 @@ function codegen_choice_gradients(trace_type::Type{T}, selection_type::Type,
 
     # return values
     push!(stmts, :(return ($input_grads, $value_trie, $gradient_trie)))
-    
+
     Expr(:block, stmts...)
 end
 
@@ -493,20 +493,20 @@ function codegen_accumulate_param_gradients!(trace_type::Type{T},
 
     # return values
     push!(stmts, :(return $input_grads))
-    
+
     Expr(:block, stmts...)
 end
 
 
 push!(generated_functions, quote
-@generated function $(Expr(:(.), Gen, QuoteNode(:choice_gradients)))(trace::T, selection::$(QuoteNode(Selection)),
+@generated function $(GlobalRef(Gen, :choice_gradients))(trace::T, selection::$(QuoteNode(Selection)),
                                        retval_grad) where {T<:$(QuoteNode(StaticIRTrace))}
     $(QuoteNode(codegen_choice_gradients))(trace, selection, retval_grad)
 end
 end)
 
 push!(generated_functions, quote
-@generated function $(Expr(:(.), Gen, QuoteNode(:accumulate_param_gradients!)))(trace::T, retval_grad) where {T<:$(QuoteNode(StaticIRTrace))}
+@generated function $(GlobalRef(Gen, :accumulate_param_gradients!))(trace::T, retval_grad) where {T<:$(QuoteNode(StaticIRTrace))}
     $(QuoteNode(codegen_accumulate_param_gradients!))(trace, retval_grad)
 end
 end)

--- a/src/static_ir/project.jl
+++ b/src/static_ir/project.jl
@@ -20,10 +20,10 @@ function process!(state::StaticIRProjectState, node::GenerativeFunctionCallNode)
     subtrace = get_subtrace_fieldname(node)
     subselection = gensym("subselection")
     if isa(schema, AllAddressSchema) || (isa(schema, StaticAddressSchema) && (node.addr in keys(schema)))
-        push!(state.stmts, :($subselection = $qn_static_getindex(selection, Val($addr))))
-        push!(state.stmts, :($weight += $qn_project(trace.$subtrace, $subselection)))
+        push!(state.stmts, :($subselection = $(GlobalRef(Gen, :static_getindex))(selection, Val($addr))))
+        push!(state.stmts, :($weight += $(GlobalRef(Gen, :project))(trace.$subtrace, $subselection)))
     else
-        push!(state.stmts, :($weight += $qn_project(trace.$subtrace, $qn_empty_selection)))
+        push!(state.stmts, :($weight += $(GlobalRef(Gen, :project))(trace.$subtrace, $(GlobalRef(Gen, :EmptySelection))())))
     end
 end
 
@@ -33,7 +33,7 @@ function codegen_project(trace_type::Type, selection_type::Type)
 
     # convert the selection to a static selection if it is not already one
     if !(isa(schema, StaticAddressSchema) || isa(schema, EmptyAddressSchema) || isa(schema, AllAddressSchema))
-        return quote $qn_project(trace, $(QuoteNode(StaticSelection))(selection)) end
+        return quote $(GlobalRef(Gen, :project))(trace, $(QuoteNode(StaticSelection))(selection)) end
     end
 
     ir = get_ir(gen_fn_type)
@@ -56,11 +56,11 @@ end
 
 push!(generated_functions, quote
 
-@generated function $(Expr(:(.), Gen, QuoteNode(:project)))(trace::T, selection::$(QuoteNode(Selection))) where {T <: $(QuoteNode(StaticIRTrace))}
+@generated function $(GlobalRef(Gen, :project))(trace::T, selection::$(QuoteNode(Selection))) where {T <: $(QuoteNode(StaticIRTrace))}
     $(QuoteNode(codegen_project))(trace, selection)
 end
 
-function $(Expr(:(.), Gen, QuoteNode(:project)))(trace::T, selection::$(QuoteNode(EmptySelection))) where {T <: $(QuoteNode(StaticIRTrace))}
+function $(GlobalRef(Gen, :project))(trace::T, selection::$(QuoteNode(EmptySelection))) where {T <: $(QuoteNode(StaticIRTrace))}
     trace.$total_noise_fieldname
 end
 

--- a/src/static_ir/static_ir.jl
+++ b/src/static_ir/static_ir.jl
@@ -51,7 +51,7 @@ function generate_generative_function(ir::StaticIR, name::Symbol, options::Stati
             params_grad::Dict{Symbol,Any}
             params::Dict{Symbol,Any}
         end
-        (gen_fn::$gen_fn_type_name)(args...) = propose(gen_fn, args)[3]
+        (gen_fn::$gen_fn_type_name)(args...) = $(Expr(:(.), Gen, QuoteNode(:propose)))(gen_fn, args)[3]
         $(Expr(:(.), Gen, QuoteNode(:get_ir)))(::Type{$gen_fn_type_name}) = $(QuoteNode(ir))
         $(Expr(:(.), Gen, QuoteNode(:get_trace_type)))(::Type{$gen_fn_type_name}) = $trace_struct_name
         $(Expr(:(.), Gen, QuoteNode(:has_argument_grads)))(::$gen_fn_type_name) = $(QuoteNode(has_argument_grads))

--- a/src/static_ir/static_ir.jl
+++ b/src/static_ir/static_ir.jl
@@ -51,14 +51,14 @@ function generate_generative_function(ir::StaticIR, name::Symbol, options::Stati
             params_grad::Dict{Symbol,Any}
             params::Dict{Symbol,Any}
         end
-        (gen_fn::$gen_fn_type_name)(args...) = $(Expr(:(.), Gen, QuoteNode(:propose)))(gen_fn, args)[3]
-        $(Expr(:(.), Gen, QuoteNode(:get_ir)))(::Type{$gen_fn_type_name}) = $(QuoteNode(ir))
-        $(Expr(:(.), Gen, QuoteNode(:get_trace_type)))(::Type{$gen_fn_type_name}) = $trace_struct_name
-        $(Expr(:(.), Gen, QuoteNode(:has_argument_grads)))(::$gen_fn_type_name) = $(QuoteNode(has_argument_grads))
-        $(Expr(:(.), Gen, QuoteNode(:accepts_output_grad)))(::$gen_fn_type_name) = $(QuoteNode(accepts_output_grad))
-        $(Expr(:(.), Gen, QuoteNode(:get_gen_fn)))(trace::$trace_struct_name) = $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref)))
-        $(Expr(:(.), Gen, QuoteNode(:get_gen_fn_type)))(::Type{$trace_struct_name}) = $gen_fn_type_name
-        $(Expr(:(.), Gen, QuoteNode(:get_options)))(::Type{$gen_fn_type_name}) = $(QuoteNode(options))
+        (gen_fn::$gen_fn_type_name)(args...) = $(GlobalRef(Gen, :propose))(gen_fn, args)[3]
+        $(GlobalRef(Gen, :get_ir))(::Type{$gen_fn_type_name}) = $(QuoteNode(ir))
+        $(GlobalRef(Gen, :get_trace_type))(::Type{$gen_fn_type_name}) = $trace_struct_name
+        $(GlobalRef(Gen, :has_argument_grads))(::$gen_fn_type_name) = $(QuoteNode(has_argument_grads))
+        $(GlobalRef(Gen, :accepts_output_grad))(::$gen_fn_type_name) = $(QuoteNode(accepts_output_grad))
+        $(GlobalRef(Gen, :get_gen_fn))(trace::$trace_struct_name) = $(Expr(:(.), :trace, QuoteNode(static_ir_gen_fn_ref)))
+        $(GlobalRef(Gen, :get_gen_fn_type))(::Type{$trace_struct_name}) = $gen_fn_type_name
+        $(GlobalRef(Gen, :get_options))(::Type{$gen_fn_type_name}) = $(QuoteNode(options))
     end
     Expr(:block, trace_defns, gen_fn_defn, Expr(:call, gen_fn_type_name, :(Dict{Symbol,Any}()), :(Dict{Symbol,Any}())))
 end
@@ -73,31 +73,6 @@ include("render_ir.jl")
 const trace = gensym("trace")
 const weight = gensym("weight")
 const subtrace = gensym("subtrace")
-
-# quoted values and function called in generated code (since generated code is
-# evaluted in the user's Main module, not Gen)
-const qn_isempty = QuoteNode(isempty)
-const qn_get_score = QuoteNode(get_score)
-const qn_get_retval = QuoteNode(get_retval)
-const qn_project = QuoteNode(project)
-const qn_logpdf = QuoteNode(logpdf)
-const qn_get_choices = QuoteNode(get_choices)
-const qn_random = QuoteNode(random)
-const qn_simulate = QuoteNode(simulate)
-const qn_generate = QuoteNode(generate)
-const qn_update = QuoteNode(update)
-const qn_regenerate = QuoteNode(regenerate)
-const qn_strip_diff = QuoteNode(strip_diff)
-const qn_get_diff = QuoteNode(get_diff)
-const qn_Diffed = QuoteNode(Diffed)
-const qn_unknown_change = QuoteNode(UnknownChange())
-const qn_no_change = QuoteNode(NoChange())
-const qn_get_internal_node = QuoteNode(get_internal_node)
-const qn_static_get_value = QuoteNode(static_get_value)
-const qn_static_get_submap = QuoteNode(static_get_submap)
-const qn_static_getindex = QuoteNode(static_getindex) # for getting a subselection
-const qn_empty_choice_map = QuoteNode(EmptyChoiceMap())
-const qn_empty_selection = QuoteNode(EmptySelection())
 
 include("simulate.jl")
 include("generate.jl")


### PR DESCRIPTION
Addresses #272. Improper scoping was showing up in two areas:
- the call to `propose` in `generate_generative_function`.
- various generated methods for `StaticIRTrace`, e.g., `get_index`

This PR addresses them by interpolating the appropriately scoped references.

It also fixes a small bug that was unfortunately introduced by my fix in #223 that was also causing issues with SML parsing. Apparently my initial attempt at protecting quoted expressions from pre-processing (in order to fix #235) was too aggressive, and ended up protecting QuoteNodes with Symbol values as well -- but QuoteNodes with Symbol values are how Julia represents something like `:(Gen.@trace)`, which meant that these expressions were getting protected instead of appropriately resolved by `resolve_gen_macros`.