### PR TITLE
Trim trailing whitespaces from .jl files using sed script.

### DIFF
--- a/examples/coal/coal.jl
+++ b/examples/coal/coal.jl
@@ -4,7 +4,7 @@ using Gen
 include("poisson_process.jl")
 
 # Example from Section 4 of Reversible jump Markov chain Monte Carlo
-# computation and Bayesian model determination 
+# computation and Bayesian model determination
 
 # minimum of k draws from uniform_continuous(lower, upper)
 
@@ -240,7 +240,7 @@ end
 
     # current number of changepoints
     k = @read_discrete_from_model(K)
-    
+
     # if k == 0, then we can only do a birth move
     isbirth = (k == 0) || @read_discrete_from_proposal(IS_BIRTH)
 
@@ -248,7 +248,7 @@ end
     if k > 1 || isbirth
         @write_discrete_to_proposal(IS_BIRTH, !isbirth)
     end
-    
+
     # the changepoint to be added or deleted
     i = @read_discrete_from_proposal(CHOSEN)
     @copy_proposal_to_proposal(CHOSEN, CHOSEN)
@@ -376,7 +376,7 @@ end
         #cp_deleted = trace[(CHANGEPT, i)]
         #cp_prev = (i == 1) ? 0. : trace[(CHANGEPT, i-1)]
         #cp_next = (i == k) ? T : trace[(CHANGEPT, i+1)]
-        #bwd_choices[NEW_CHANGEPT] = cp_deleted 
+        #bwd_choices[NEW_CHANGEPT] = cp_deleted
 #
         ## shift down changepoints
         #for j=i:k-1
@@ -560,7 +560,7 @@ function plot_trace_plot()
     rate1 = Float64[]
     num_clusters_vec = Int[]
     burn_in = 0
-    for iter=1:burn_in + 1000 
+    for iter=1:burn_in + 1000
         trace = mcmc_step(trace)
         if iter > burn_in
             push!(num_clusters_vec, trace[K])
@@ -574,7 +574,7 @@ function plot_trace_plot()
     rate1 = Float64[]
     num_clusters_vec = Int[]
     burn_in = 0
-    for iter=1:burn_in + 1000 
+    for iter=1:burn_in + 1000
         trace = simple_mcmc_step(trace)
         if iter > burn_in
             push!(num_clusters_vec, trace[K])

--- a/examples/coal/poisson_process.jl
+++ b/examples/coal/poisson_process.jl
@@ -1,4 +1,4 @@
-# piecewise homogenous Poisson process 
+# piecewise homogenous Poisson process
 
 # n intervals - n + 1 bounds
 # (b_1, b_2]
@@ -37,7 +37,7 @@ function Gen.logpdf(::PiecewiseHomogenousPoissonProcess, x::Vector{Float64}, bou
         if xi < bounds[1] || xi > bounds[end]
             error("x ($xi) lies outside of interval")
         end
-        while xi > upper 
+        while xi > upper
             cur += 1
             upper = bounds[cur+1]
         end

--- a/examples/decode/run.jl
+++ b/examples/decode/run.jl
@@ -10,7 +10,7 @@ for (i, letter) in enumerate(alphabet)
 end
 
 # load bigram data into a transition matrix
-# bigrams.json from https://gist.github.com/lydell/c439049abac2c9226e53 
+# bigrams.json from https://gist.github.com/lydell/c439049abac2c9226e53
 data = JSON.parsefile("$(@__DIR__)/bigrams.json")
 counts = zeros(Int64, (27, 27))
 for (bigram, count) in data
@@ -121,12 +121,12 @@ function do_inference(encoded_text::AbstractString, num_iter::Int)
             choices[replica => (:code, l)] = l
         end
 
-        # initialize original text 
+        # initialize original text
         for (l, char) in enumerate(encoded_text)
             choices[replica => :text => l] = letter_to_int[char]
         end
     end
-        
+
     # initial trace
     (trace, _) = generate(par_model, (alphas, fill(len, num_replicas)), choices)
 

--- a/examples/gp_structure/incremental.jl
+++ b/examples/gp_structure/incremental.jl
@@ -108,7 +108,7 @@ const covariance_prior_incremental = Recurse(
     n = length(xs)
     cov_matrix = cov_fn_and_matrix.cov_matrix + Matrix((noise + 0.01) * LinearAlgebra.I, n, n)
 
-    # sample from multivariate normal   
+    # sample from multivariate normal
     @trace(mvnormal(zeros(n), cov_matrix), :ys)
 
     node = cov_fn_and_matrix.node
@@ -118,13 +118,13 @@ end
 Gen.load_generated_functions()
 
 @gen function subtree_proposal_recursive(cur::Int)
-    
+
     # base address for production kernel application 'cur'
     prod_addr = (cur, Val(:production))
 
     # base address for aggregation kernel application 'cur'
     agg_addr = (cur, Val(:aggregation))
-    
+
     # sample node type
     node_type = @trace(categorical(node_dist), (cur, Val(:production)) => :type)
 
@@ -228,7 +228,7 @@ function inference(xs::Vector{Float64}, ys::Vector{Float64}, num_iters::Int, cal
 
         # do MH move on the subtree
         (trace, _) = metropolis_hastings(trace, subtree_proposal, (), subtree_involution)
-        
+
         # do MH move on the top-level white noise
         (trace, _) = metropolis_hastings(trace, noise_proposal, ())
     end

--- a/examples/gp_structure/involution_mh.jl
+++ b/examples/gp_structure/involution_mh.jl
@@ -61,7 +61,7 @@ end
     # compute covariance matrix
     cov_matrix = compute_cov_matrix_vectorized(covariance_fn, noise, xs)
 
-    # sample from multivariate normal   
+    # sample from multivariate normal
     @trace(mvnormal(zeros(n), cov_matrix), :ys)
 
     return covariance_fn

--- a/examples/gp_structure/involution_mh_tree.jl
+++ b/examples/gp_structure/involution_mh_tree.jl
@@ -57,7 +57,7 @@ end
     # compute covariance matrix
     cov_matrix = compute_cov_matrix_vectorized(covariance_fn, noise, xs)
 
-    # sample from multivariate normal   
+    # sample from multivariate normal
     @trace(mvnormal(zeros(n), cov_matrix), :ys)
 
     return covariance_fn

--- a/examples/gp_structure/lightweight.jl
+++ b/examples/gp_structure/lightweight.jl
@@ -59,7 +59,7 @@ end
     # compute covariance matrix
     cov_matrix = compute_cov_matrix_vectorized(covariance_fn, noise, xs)
 
-    # sample from multivariate normal   
+    # sample from multivariate normal
     @trace(mvnormal(zeros(n), cov_matrix), :ys)
 
     return covariance_fn

--- a/examples/inverse_graphics/model.jl
+++ b/examples/inverse_graphics/model.jl
@@ -134,7 +134,7 @@ end
     # distribution over sizes of the letters
     size_alpha = exp(outputs[7])
     size_beta = exp(outputs[8])
-    
+
     # distribution over 3 possible letters
     log_letter_dist = outputs[9:9 + length(letters)-1]
     letter_dist = exp.(log_letter_dist)

--- a/examples/involution_mh_minimal_example.jl
+++ b/examples/involution_mh_minimal_example.jl
@@ -105,9 +105,9 @@ println(zs)
 
 function plots()
     Random.seed!(2)
-    
+
     figure(figsize=(6, 3))
-    
+
     subplot(2, 2, 1)
     y1, y2 = (1.0, 1.3)
     (zs, m, m1, m2) = do_inference_rjmcmc(y1, y2)
@@ -117,14 +117,14 @@ function plots()
     title("Involution MH (RJMCMC)")
     legend(loc="lower right")
     gca().set_ylim(0.5, 1.5)
-    
+
     subplot(2, 2, 3)
     plot(zs, label="z", color="black")
     xlabel("\\# MCMC moves")
     legend(loc="center right")
     yticks(ticks=[0, 1], labels=["F", "T"])
     gca().set_ylim(-0.1, 1.1)
-    
+
     subplot(2, 2, 2)
     y1, y2 = (1.0, 1.3)
     (zs, m, m1, m2) = do_inference_simple(y1, y2)
@@ -134,14 +134,14 @@ function plots()
     title("Selection MH")
     legend(loc="lower right")
     gca().set_ylim(0.5, 1.5)
-    
+
     subplot(2, 2, 4)
     plot(zs, label="z", color="black")
     xlabel("\\# MCMC moves")
     legend(loc="center right")
     yticks(ticks=[0, 1], labels=["F", "T"])
     gca().set_ylim(-0.1, 1.1)
-    
+
     tight_layout()
     savefig("rjmcmc.png")
 end

--- a/examples/kernel_dsl.jl
+++ b/examples/kernel_dsl.jl
@@ -31,7 +31,7 @@ function add_remove_involution(trace, fwd_choices, ret, args)
     bwd_choices = choicemap()
     new_n = add ? n + 1 : n - 1
     constraints = choicemap((:n, new_n))
-    if add 
+    if add
         bwd_choices[:add] = false
         constraints[(:x, new_n)] = fwd_choices[:new_x]
     else
@@ -67,7 +67,7 @@ max_n_add_remove = 10 # to test that we have escaped the body of the kern proper
 
 ex = quote
 @kern function my_kernel(trace)
-    
+
     # cycle through the x's and do a random walk update on each one
     for i in 1:trace[:n]
         trace ~ mh(trace, random_walk_proposal, (i,))

--- a/examples/planning/demo.jl
+++ b/examples/planning/demo.jl
@@ -6,7 +6,7 @@ using Printf: @sprintf
 import Random
 
 function make_scene()
-    scene = Scene(0, 1, 0, 1) 
+    scene = Scene(0, 1, 0, 1)
     add!(scene, Tree(Point(0.30, 0.20), size=0.1))
     add!(scene, Tree(Point(0.83, 0.80), size=0.1))
     add!(scene, Tree(Point(0.80, 0.40), size=0.1))

--- a/examples/planning/filtering.jl
+++ b/examples/planning/filtering.jl
@@ -99,7 +99,7 @@ function compute_custom_proposal_params(dt::Float64, prev_dist::Float64, noise::
                                         posterior_var_d::Float64, posterior_covars::Vector{Matrix{Float64}},
                                         path::Path, distances_from_start::Vector{Float64},
                                         speed::Float64, dist_slack::Float64)
-    
+
     N = length(path.points)
 
     # Initialize parameters for truncated normal
@@ -111,7 +111,7 @@ function compute_custom_proposal_params(dt::Float64, prev_dist::Float64, noise::
     mus[1] = prev_dist + dt * speed
     stds[1] = dist_slack
     unnormalized_log_segment_probs[1] = Distributions.logcdf(Distributions.Normal(mus[1], stds[1]), 0) + Distributions.logpdf(Distributions.Normal(path.start.x, noise), obs.x) + Distributions.logpdf(Distributions.Normal(path.start.y, noise), obs.y)
-   
+
     # Last segment
     mus[N+1] = prev_dist + dt * speed
     stds[N+1] = dist_slack
@@ -119,12 +119,12 @@ function compute_custom_proposal_params(dt::Float64, prev_dist::Float64, noise::
 
     # Middle segments
     for i=2:N
-        dx = path.points[i].x - path.points[i-1].x 
+        dx = path.points[i].x - path.points[i-1].x
         dy = path.points[i].y - path.points[i-1].y
         dd = distances_from_start[i] - distances_from_start[i-1]
 
         prior_mu_d = mus[1] - distances_from_start[i-1]
-        x_obs = obs.x - path.points[i-1].x 
+        x_obs = obs.x - path.points[i-1].x
         y_obs = obs.y - path.points[i-1].y
 
         posterior_mu_d = posterior_var_d * ((dx * x_obs + dy * y_obs) / (dd * noise^2) + prior_mu_d / dist_slack^2)
@@ -192,7 +192,7 @@ static_fancy_proposal = at_dynamic(static_markov_fancy_proposal_inner, Int)
 #############################
 
 function make_scene()
-    scene = Scene(0, 1, 0, 1) 
+    scene = Scene(0, 1, 0, 1)
     add!(scene, Tree(Point(0.30, 0.20), size=0.1))
     add!(scene, Tree(Point(0.83, 0.80), size=0.1))
     add!(scene, Tree(Point(0.80, 0.40), size=0.1))
@@ -276,7 +276,7 @@ function render_lightweight_hmm_trace(scene::Scene, start::Point, stop::Point,
             ax[:add_patch](circle)
         end
     end
-    
+
     # plot measured locations
     assignment = get_choices(trace)
     if show_measurements
@@ -330,7 +330,7 @@ function render_static_hmm_trace(scene::Scene, start::Point, stop::Point,
             ax[:add_patch](circle)
         end
     end
-    
+
     # plot measured locations
     assignment = get_choices(trace)
     if show_measurements
@@ -414,7 +414,7 @@ function PrecomputedPathData(params::Params)
     posterior_covars = Vector{Matrix{Float64}}(undef, length(distances_from_start))
     for i = 2:length(distances_from_start)
         dd = distances_from_start[i] - distances_from_start[i-1]
-        dx = path.points[i].x - path.points[i-1].x 
+        dx = path.points[i].x - path.points[i-1].x
         dy = path.points[i].y - path.points[i-1].y
         posterior_covars[i] = [noise 0; 0 noise] .+ (dist_slack^2/dd^2 .* [dx^2 dx*dy; dy*dx dy^2])
     end
@@ -566,7 +566,7 @@ function particle_filtering_lightweight_hmm_default_proposal(params::Params,
         lmls = Vector{Float64}(undef, num_reps)
         for rep=1:num_reps
             start = time_ns()
-            (traces, _, lml) = particle_filter(lightweight_hmm, model_args_rest, max_steps, 
+            (traces, _, lml) = particle_filter(lightweight_hmm, model_args_rest, max_steps,
                                                num_particles, ess_threshold, obs)
             elapsed[rep] = Int(time_ns() - start) / 1e9
             println("num_particles: $num_particles, lml estimate: $lml, elapsed: $(elapsed[rep])")
@@ -679,7 +679,7 @@ function particle_filtering_lightweight_markov_hmm_default_proposal(params::Para
         lmls = Vector{Float64}(undef, num_reps)
         for rep=1:num_reps
             start = time_ns()
-            (traces, _, lml) = particle_filter(lightweight_hmm_with_markov, model_args_rest, max_steps, 
+            (traces, _, lml) = particle_filter(lightweight_hmm_with_markov, model_args_rest, max_steps,
                                                num_particles, ess_threshold, obs)
             elapsed[rep] = Int(time_ns() - start) / 1e9
             println("num_particles: $num_particles, lml estimate: $lml, elapsed: $(elapsed[rep])")

--- a/examples/planning/model.jl
+++ b/examples/planning/model.jl
@@ -17,7 +17,7 @@ using PyPlot
 
     # plan a path that avoids obstacles in the scene
     maybe_path = plan_path(start, stop, scene, PlannerParams(300, 3.0, 2000, 1.))
-    
+
     # speed
     speed = @trace(uniform(0, 1), :speed)
 
@@ -72,7 +72,7 @@ function render(scene::Scene, trace, ax;
             ax[:add_patch](circle)
         end
     end
-    
+
     # plot measured locations
     if show_measurements
         measured_xs = [assignment[i => :x] for i=1:length(locations)]

--- a/examples/planning/path_planner.jl
+++ b/examples/planning/path_planner.jl
@@ -97,7 +97,7 @@ function random_config(scheme::HolonomicPointRRTScheme)
     Point(x, y)
 end
 
-function select_control(scheme::HolonomicPointRRTScheme, 
+function select_control(scheme::HolonomicPointRRTScheme,
                         target_conf::Point, start_conf::Point, dt::Float64)
 
     dist_to_target = dist(start_conf, target_conf)
@@ -108,7 +108,7 @@ function select_control(scheme::HolonomicPointRRTScheme,
 
     obstacles = scheme.scene.obstacles
 
-    # go in the direction of target_conf from start_conf 
+    # go in the direction of target_conf from start_conf
     new_conf = Point(start_conf.x + control.x, start_conf.y + control.y)
 
     # test the obstacles
@@ -200,7 +200,7 @@ function refine_path(scene::Scene, original::Path, iters::Int, std::Float64)
         ok_forward = line_of_site(scene, adjusted, next_point)
         if ok_backward && ok_forward
             new_dist = dist(prev_point, adjusted) + dist(adjusted, next_point)
-            if new_dist < cur_dist 
+            if new_dist < cur_dist
                 # accept the change
                 new_points[point_idx] = adjusted
             end
@@ -257,7 +257,7 @@ function plan_path(start::Point, goal::Point, scene::Scene,
     else
         path = Nullable{Path}()
     end
-    
+
     local optimized_path::Nullable{Path}
     if path_found
         optimized_path = Nullable{Path}(optimize_path(scene, get(path),

--- a/examples/planning/static_demo.jl
+++ b/examples/planning/static_demo.jl
@@ -6,7 +6,7 @@ using Printf: @sprintf
 import Random
 
 function make_scene()
-    scene = Scene(0, 1, 0, 1) 
+    scene = Scene(0, 1, 0, 1)
     add!(scene, Tree(Point(0.30, 0.20), size=0.1))
     add!(scene, Tree(Point(0.83, 0.80), size=0.1))
     add!(scene, Tree(Point(0.80, 0.40), size=0.1))

--- a/examples/planning/static_model.jl
+++ b/examples/planning/static_model.jl
@@ -34,7 +34,7 @@ measurements = Map(measurement)
 
     # plan a path that avoids obstacles in the scene
     maybe_path = plan_path(start, stop, scene, PlannerParams(300, 3.0, 2000, 1.))
-    
+
     # speed
     speed = @trace(uniform(0, 1), :speed)
 
@@ -82,7 +82,7 @@ function render(scene::Scene, trace, ax;
             ax[:add_patch](circle)
         end
     end
-    
+
     # plot measured locations
     if show_measurements
         measured_xs = [assignment[:measurements => i => :x] for i=1:length(locations)]

--- a/examples/pmmh/model.jl
+++ b/examples/pmmh/model.jl
@@ -174,10 +174,10 @@ function unbiased_logpdf_est(args, ys::PersistentVector{Float64})
     retval = PersistentVector{Float64}(ys)
     vector = VectorDistTrace(retval, args, lml_estimate, length(ys))
     CollapsedHMMTrace(vector)
-end 
+end
 
 function Gen.generate(generator::CollapsedHMM, args, constraints)
-    (var_x, var_y, T, num_particles, ess) = args 
+    (var_x, var_y, T, num_particles, ess) = args
     if isempty(constraints)
         error("Unsupported constraints")
     end

--- a/examples/pmmh/pf.jl
+++ b/examples/pmmh/pf.jl
@@ -42,7 +42,7 @@ function run_particle_filter(gen_fn::ParticleFilterCombinator, args::Tuple, choi
     init_obs = choicemap()
     set_submap!(init_obs, :init_emission, get_submap(choices, 1))
     init_args = (0, initial_args, dynamics_args, emission_args)
-    state = initialize_particle_filter(gen_fn.combined, 
+    state = initialize_particle_filter(gen_fn.combined,
         init_args, init_obs, num_particles)
     argdiff = UnfoldCustomArgDiff(false, false)
     for t=2:T

--- a/examples/regression/dynamic_map_optimize_gibbs.jl
+++ b/examples/regression/dynamic_map_optimize_gibbs.jl
@@ -25,7 +25,7 @@ function do_inference(xs, ys, num_iters)
     end
     observations[:log_inlier_std] = 0.
     observations[:log_outlier_std] = 0.
- 
+
     # initial trace
     (trace, _) = generate(model, (xs,), observations)
 
@@ -33,15 +33,15 @@ function do_inference(xs, ys, num_iters)
     for i=1:num_iters
         trace = map_optimize(trace, slope_intercept_selection, max_step_size=1., min_step_size=1e-10)
         trace = map_optimize(trace, std_selection, max_step_size=1., min_step_size=1e-10)
-    
+
         # gibbs step on the outliers
         for j=1:length(xs)
             (trace, _) = metropolis_hastings(trace, gibbs_proposal, (j,))
         end
-    
+
         score = get_score(trace)
         scores[i] = score
-    
+
         # print
         assignment = get_choices(trace)
         slope = assignment[:slope]

--- a/examples/regression/dynamic_resimulation_mh.jl
+++ b/examples/regression/dynamic_resimulation_mh.jl
@@ -17,10 +17,10 @@ function do_inference(xs, ys, num_iters)
 
     # initial trace
     (trace, _) = generate(model, (xs,), observations)
-    
+
     scores = Vector{Float64}(undef, num_iters)
     for i=1:num_iters
-    
+
         # steps on the parameters
         for j=1:5
             (trace, _) = metropolis_hastings(trace, select(:slope))
@@ -28,12 +28,12 @@ function do_inference(xs, ys, num_iters)
             (trace, _) = metropolis_hastings(trace, select(:log_inlier_std))
             (trace, _) = metropolis_hastings(trace, select(:log_outlier_std))
         end
-    
+
         # step on the outliers
         for j=1:length(xs)
             (trace, _) = metropolis_hastings(trace, is_outlier_proposal, (j,))
         end
-    
+
         score = get_score(trace)
         scores[i] = score
 

--- a/examples/regression/static_mala_hmc.jl
+++ b/examples/regression/static_mala_hmc.jl
@@ -23,10 +23,10 @@ function do_inference(xs, ys, num_iters)
     end
     observations[:log_inlier_std] = 0.
     observations[:log_outlier_std] = 0.
-    
+
     # initial trace
     (trace, _) = generate(model, (xs,), observations)
-    
+
     scores = Vector{Float64}(undef, num_iters)
     for i=1:num_iters
         trace, = hmc(trace, line_selection; eps=1e-2, L=10)
@@ -38,10 +38,10 @@ function do_inference(xs, ys, num_iters)
         for j=1:length(xs)
             (trace, _) = metropolis_hastings(trace, is_outlier_proposal, (j,))
         end
-    
+
         score = get_score(trace)
         scores[i] = score
-    
+
         # print
         slope = trace[:slope]
         intercept = trace[:intercept]

--- a/examples/regression/static_map_optimize.jl
+++ b/examples/regression/static_map_optimize.jl
@@ -30,15 +30,15 @@ function do_inference(xs, ys, num_iters)
     for i=1:num_iters
         trace = map_optimize(trace, slope_intercept_selection, max_step_size=1., min_step_size=1e-10)
         trace = map_optimize(trace, std_selection, max_step_size=1., min_step_size=1e-10)
-    
+
         # step on the outliers
         for j=1:length(xs)
             (trace, _) = metropolis_hastings(trace, is_outlier_proposal, (j,))
         end
-    
+
         score = get_score(trace)
         scores[i] = score
-    
+
         # print
         slope = trace[:slope]
         intercept = trace[:intercept]

--- a/examples/regression/static_mh.jl
+++ b/examples/regression/static_mh.jl
@@ -121,7 +121,7 @@ function log_likelihood(state)
 end
 
 macro parameter_mh_move!(state, addr)
-    quote 
+    quote
         prev_ll = log_likelihood($(esc(state)))
         prev_val = $(esc(state)).$addr
         new_val = normal(prev_val, 0.5)
@@ -129,7 +129,7 @@ macro parameter_mh_move!(state, addr)
         new_prior = logpdf(normal, new_val, 0, 2)
         $(esc(state)).$addr = new_val
         new_ll = log_likelihood($(esc(state)))
-        if log(rand()) >= new_ll - prev_ll + new_prior - prev_prior 
+        if log(rand()) >= new_ll - prev_ll + new_prior - prev_prior
             $(esc(state)).$addr = prev_val # reject
         end
     end

--- a/src/address.jl
+++ b/src/address.jl
@@ -10,9 +10,9 @@ end
 
 Base.keys(schema::StaticAddressSchema) = schema.keys
 
-struct VectorAddressSchema <: AddressSchema end 
-struct SingleDynamicKeyAddressSchema <: AddressSchema end 
-struct DynamicAddressSchema <: AddressSchema end 
+struct VectorAddressSchema <: AddressSchema end
+struct SingleDynamicKeyAddressSchema <: AddressSchema end
+struct DynamicAddressSchema <: AddressSchema end
 struct EmptyAddressSchema <: AddressSchema end
 struct AllAddressSchema <: AddressSchema end
 
@@ -315,7 +315,7 @@ function Base.push!(selection::DynamicSelection, addr::Pair)
         subselection = selection.subselections[first]
     else
         subselection = DynamicSelection()
-        selection.subselections[first] = subselection 
+        selection.subselections[first] = subselection
     end
     push!(subselection, rest)
 end
@@ -330,7 +330,7 @@ function set_subselection!(selection::DynamicSelection, addr::Pair, other::Selec
         subselection = selection.subselections[first]
     else
         subselection = DynamicSelection()
-        selection.subselections[first] = subselection 
+        selection.subselections[first] = subselection
     end
     set_subselection!(subselection, rest, other)
 end

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -501,7 +501,7 @@ end
         push!(internal_node_names, node)
         push!(exprs, quote
             (n_read, $node) = _from_array(proto_choices.internal_nodes.$key, arr, idx)
-            idx += n_read 
+            idx += n_read
         end)
     end
 
@@ -625,7 +625,7 @@ end
 
 function DynamicChoiceMap(tuples...)
     choices = DynamicChoiceMap()
-    for (addr, value) in tuples 
+    for (addr, value) in tuples
         choices[addr] = value
     end
     choices

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -5,7 +5,7 @@
 # NOTE: values encountered during an update that are not wrapped in Diffed are
 # assumed to have not changed (i.e. constants)
 
-# NOTE: the requirement is that if a method takes any Diffed arguments, it must 
+# NOTE: the requirement is that if a method takes any Diffed arguments, it must
 # return a Diffed value.
 
 # a Julia method may take non-diffed arguments (which indicate no change, in
@@ -36,7 +36,7 @@ abstract type Diff end
 
 No information is provided about the change to the value.
 """
-struct UnknownChange <: Diff end 
+struct UnknownChange <: Diff end
 
 """
     NoChange
@@ -58,18 +58,18 @@ struct DictDiff{K,V} <: Diff
 
     # keys that that were added and their values
     added::AbstractDict{K,V}
-    
+
     # keys that were deleted
     deleted::AbstractSet{K}
 
     # map from key to diff value for that key
-    updated::AbstractDict{K,Diff} 
+    updated::AbstractDict{K,Diff}
 end
 
 struct VectorDiff <: Diff
     new_length::Int
     prev_length::Int
-    updated::Dict{Int,Diff} 
+    updated::Dict{Int,Diff}
 end
 
 struct IntDiff <: Diff
@@ -249,7 +249,7 @@ function Base.getindex(vec::Diffed{T,VectorDiff}, idx::Union{Diffed{U,NoChange},
     d = get_diff(vec)
     result = v[i]
     if i > d.prev_length
-        Diffed(result, UnknownChange()) 
+        Diffed(result, UnknownChange())
     elseif haskey(d.updated, i)
         Diffed(result, d.updated[i])
     else
@@ -266,7 +266,7 @@ macro diffed_unary_function(fn)
         function $(fn)(value::Diffed{T,NoChange}) where {T}
             Diffed($(fn)(strip_diff(value)), NoChange())
         end
-        
+
         function $(fn)(value::Diffed{T,UnknownChange}) where {T}
             Diffed($(fn)(strip_diff(value)), UnknownChange())
         end

--- a/src/dynamic/backprop.jl
+++ b/src/dynamic/backprop.jl
@@ -105,7 +105,7 @@ function traceat(state::GFBackpropParamsState, gen_fn::GenerativeFunction{T},
     record!(state.tape, ReverseDiff.SpecialInstruction,
         BackpropParamsRecord(gen_fn, subtrace, state.scale_factor),
         (args_maybe_tracked...,), retval_maybe_tracked)
-    retval_maybe_tracked 
+    retval_maybe_tracked
 end
 
 function splice(state::GFBackpropParamsState, gen_fn::DynamicDSLFunction,
@@ -113,7 +113,7 @@ function splice(state::GFBackpropParamsState, gen_fn::DynamicDSLFunction,
 
     # save previous tracked parameter scope
     prev_tracked_params = state.tracked_params
-    
+
     # construct new tracked parameter scope
     state.tracked_params = Dict{Symbol,Any}()
     for name in keys(gen_fn.params)
@@ -321,7 +321,7 @@ function traceat(state::GFBackpropTraceState, gen_fn::GenerativeFunction{T,U},
     record = BackpropTraceRecord(gen_fn, subtrace, selection, state.value_choices,
         state.gradient_choices, key)
     record!(state.tape, ReverseDiff.SpecialInstruction, record, (args_maybe_tracked...,), retval_maybe_tracked)
-    retval_maybe_tracked 
+    retval_maybe_tracked
 end
 
 function splice(state::GFBackpropTraceState, gen_fn::DynamicDSLFunction,

--- a/src/dynamic/generate.jl
+++ b/src/dynamic/generate.jl
@@ -81,7 +81,7 @@ end
 function generate(gen_fn::DynamicDSLFunction, args::Tuple,
                     constraints::ChoiceMap)
     state = GFGenerateState(gen_fn, args, constraints, gen_fn.params)
-    retval = exec(gen_fn, state, args) 
+    retval = exec(gen_fn, state, args)
     set_retval!(state.trace, retval)
     (state.trace, state.weight)
 end

--- a/src/dynamic/propose.jl
+++ b/src/dynamic/propose.jl
@@ -22,9 +22,9 @@ function traceat(state::GFProposeState, dist::Distribution{T},
     # update assignment
     set_value!(state.choices, key, retval)
 
-    # update weight 
+    # update weight
     state.weight += logpdf(dist, retval, args...)
-    
+
     retval
 end
 

--- a/src/dynamic/regenerate.jl
+++ b/src/dynamic/regenerate.jl
@@ -22,7 +22,7 @@ function traceat(state::GFRegenerateState, dist::Distribution{T},
     # check that key was not already visited, and mark it as visited
     visit!(state.visitor, key)
 
-    # check for previous choice at this key 
+    # check for previous choice at this key
     has_previous = has_choice(state.prev_trace, key)
     if has_previous
         prev_choice = get_choice(state.prev_trace, key)

--- a/src/dynamic/simulate.jl
+++ b/src/dynamic/simulate.jl
@@ -58,7 +58,7 @@ end
 
 function simulate(gen_fn::DynamicDSLFunction, args::Tuple)
     state = GFSimulateState(gen_fn, args, gen_fn.params)
-    retval = exec(gen_fn, state, args) 
+    retval = exec(gen_fn, state, args)
     set_retval!(state.trace, retval)
     state.trace
 end

--- a/src/dynamic/update.jl
+++ b/src/dynamic/update.jl
@@ -16,7 +16,7 @@ function GFUpdateState(gen_fn, args, prev_trace, constraints, params)
         0., visitor, params, discard)
 end
 
-function traceat(state::GFUpdateState, dist::Distribution{T}, 
+function traceat(state::GFUpdateState, dist::Distribution{T},
                  args::Tuple, key) where {T}
 
     local prev_retval::T
@@ -30,7 +30,7 @@ function traceat(state::GFUpdateState, dist::Distribution{T},
     if has_previous
         prev_choice = get_choice(state.prev_trace, key)
         prev_retval = prev_choice.retval
-        prev_score = prev_choice.score 
+        prev_score = prev_choice.score
     end
 
     # check for constraints at this key
@@ -41,7 +41,7 @@ function traceat(state::GFUpdateState, dist::Distribution{T},
     if constrained && has_previous
         set_value!(state.discard, key, prev_retval)
     end
-    
+
     # get return value
     if constrained
         retval = get_value(state.constraints, key)
@@ -92,7 +92,7 @@ function traceat(state::GFUpdateState, gen_fn::GenerativeFunction{T,U},
     else
         (subtrace, weight) = generate(gen_fn, args, constraints)
     end
-    
+
     # update the weight
     state.weight += weight
 
@@ -162,7 +162,7 @@ function add_unvisited_to_discard!(discard::DynamicChoiceMap,
             # the recursive call to update already handled the discard
             # for this entire submap
             continue
-        else 
+        else
             subvisited = visited[key]
             if isempty(subvisited)
                 # none of this submap was visited, so we discard the whole thing
@@ -183,7 +183,7 @@ function update(trace::DynamicDSLTrace, arg_values::Tuple, arg_diffs::Tuple,
                 constraints::ChoiceMap)
     gen_fn = trace.gen_fn
     state = GFUpdateState(gen_fn, arg_values, trace, constraints, gen_fn.params)
-    retval = exec(gen_fn, state, arg_values) 
+    retval = exec(gen_fn, state, arg_values)
     set_retval!(state.trace, retval)
     visited = get_visited(state.visitor)
     state.weight -= update_delete_recurse(trace.trie, visited)

--- a/src/inference/involution_dsl.jl
+++ b/src/inference/involution_dsl.jl
@@ -289,7 +289,7 @@ macro invcall(ex)
     quote $(esc(f)).fn!($(esc(inv_state)), $(map(esc, args)...)) end
 end
 
-# apply 
+# apply
 
 function apply_involution(involution::InvolutionDSLProgram, trace, u, proposal_args, proposal_retval)
 
@@ -358,7 +358,7 @@ function apply_involution(involution::InvolutionDSLProgram, trace, u, proposal_a
         output_arr = Vector{T}(undef, n_output)
 
         jacobian_pass_state = JacobianPassState(
-            trace, u, input_arr, output_arr, 
+            trace, u, input_arr, output_arr,
             t_key_to_index, u_key_to_index,
             cont_constraints_key_to_index,
             cont_u_back_key_to_index)

--- a/src/inference/kernel_dsl.jl
+++ b/src/inference/kernel_dsl.jl
@@ -213,7 +213,7 @@ macro kern(ex)
     quote
         # define forward kerel
         $kern_ex
-        
+
         # define reversal kernel
         $rev_kern_ex
 

--- a/src/inference/map_optimize.jl
+++ b/src/inference/map_optimize.jl
@@ -1,5 +1,5 @@
 """
-    new_trace = map_optimize(trace, selection::Selection, 
+    new_trace = map_optimize(trace, selection::Selection,
         max_step_size=0.1, tau=0.5, min_step_size=1e-16, verbose=false)
 
 Perform backtracking gradient ascent to optimize the log probability of the trace over selected continuous choices.
@@ -34,7 +34,7 @@ function map_optimize(trace, selection::Selection;
             # it got worse, but we ran out of attempts
             return trace
         end
-        
+
         # try again with a smaller step size
         step_size = tau * step_size
     end

--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -146,12 +146,12 @@ function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, a
         @assert isempty(disc)
         state.log_weights[i] += up_weight - prop_weight
     end
-    
+
     # swap references
     tmp = state.traces
     state.traces = state.new_traces
     state.new_traces = tmp
-    
+
     return nothing
 end
 
@@ -172,12 +172,12 @@ function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, a
         end
         state.log_weights[i] += increment
     end
-    
+
     # swap references
     tmp = state.traces
     state.traces = state.new_traces
     state.new_traces = tmp
-    
+
     return nothing
 end
 
@@ -205,7 +205,7 @@ function maybe_resample!(state::ParticleFilterState{U};
             state.new_traces[i] = state.traces[state.parents[i]]
             state.log_weights[i] = 0.
         end
-        
+
         # swap references
         tmp = state.traces
         state.traces = state.new_traces

--- a/src/inference/train.jl
+++ b/src/inference/train.jl
@@ -55,7 +55,7 @@ function train!(gen_fn::GenerativeFunction, data_generator::Function,
             avg_score += weight
         end
         avg_score /= evaluation_size
-        
+
         history[epoch] = avg_score
 
         if verbose

--- a/src/inference/variational.jl
+++ b/src/inference/variational.jl
@@ -129,7 +129,7 @@ function black_box_vi!(
         # do an update
         apply!(update)
     end
-    
+
     (elbo_history[end], traces, elbo_history)
 end
 
@@ -150,7 +150,7 @@ function black_box_vimco!(
         update::ParamUpdate, num_samples::Int;
         iters=1000, samples_per_iter=100, verbose=false,
         geometric=true)
-    
+
     traces = Vector{Any}(undef, samples_per_iter)
     iwelbo_history = Vector{Float64}(undef, iters)
     for iter=1:iters

--- a/src/modeling_library/call_at/call_at.jl
+++ b/src/modeling_library/call_at/call_at.jl
@@ -92,7 +92,7 @@ end
 function generate(gen_fn::CallAtCombinator{T,U,K}, args::Tuple,
                   choices::ChoiceMap) where {T,U,K}
     (key, kernel_args) = unpack_call_at_args(args)
-    submap = get_submap(choices, key) 
+    submap = get_submap(choices, key)
     (subtrace, weight) = generate(gen_fn.kernel, kernel_args, submap)
     trace = CallAtTrace(gen_fn, subtrace, key)
     (trace, weight)

--- a/src/modeling_library/choice_at/choice_at.jl
+++ b/src/modeling_library/choice_at/choice_at.jl
@@ -120,7 +120,7 @@ function regenerate(trace::ChoiceAtTrace, args::Tuple, argdiffs::Tuple,
     (key, kernel_args) = unpack_choice_at_args(args)
     key_changed = (key != trace.key)
     selected = key in selection
-    if !key_changed && selected 
+    if !key_changed && selected
         new_value = random(trace.gen_fn.dist, kernel_args...)
     elseif !key_changed && !selected
         new_value = trace.value
@@ -130,7 +130,7 @@ function regenerate(trace::ChoiceAtTrace, args::Tuple, argdiffs::Tuple,
         error("Cannot select new address $key in regenerate")
     end
     new_score = logpdf(trace.gen_fn.dist, new_value, kernel_args...)
-    if !key_changed && selected 
+    if !key_changed && selected
         weight = 0.
     elseif !key_changed && !selected
         weight = new_score - trace.score

--- a/src/modeling_library/custom_determ.jl
+++ b/src/modeling_library/custom_determ.jl
@@ -28,9 +28,9 @@ get_gen_fn(trace::CustomDetermGFTrace) = trace.gen_fn
 
 
 """
-    CustomDetermGF{T,S} <: GenerativeFunction{T,CustomDetermGFTrace{T,S}} 
+    CustomDetermGF{T,S} <: GenerativeFunction{T,CustomDetermGFTrace{T,S}}
 
-Abstract type for a custom deterministic generative function. 
+Abstract type for a custom deterministic generative function.
 """
 abstract type CustomDetermGF{T,S} <: GenerativeFunction{T,CustomDetermGFTrace{T,S}} end
 
@@ -57,7 +57,7 @@ function update_with_state(gen_fn::CustomDetermGF{T,S}, state, args, argdiffs) w
 end
 
 """
-    arg_grads = gradient_with_state(gen_fn::CustomDetermGF, state, args, retgrad) 
+    arg_grads = gradient_with_state(gen_fn::CustomDetermGF, state, args, retgrad)
 
 Return the gradient tuple with respect to the arguments.
 """
@@ -69,7 +69,7 @@ end
 """
     arg_grads = accumulate_param_gradients_determ!(
         gen_fn::CustomDetermGF, state, args, retgrad, scale_factor)
-    
+
 Increment gradient accumulators for parameters the gradient with respect to the
 arguments, optionally scaled, and return the gradient with respect to the
 arguments (not scaled).
@@ -163,7 +163,7 @@ function apply_with_state(gen_fn::CustomGradientGF, args)
 end
 
 """
-    arg_grads = gradient(gen_fn::CustomDetermGF, args, retval, retgrad) 
+    arg_grads = gradient(gen_fn::CustomDetermGF, args, retval, retgrad)
 
 Return the gradient tuple with respect to the arguments, where `nothing` is for argument(s) whose gradient is not available.
 """

--- a/src/modeling_library/distributions/cauchy.jl
+++ b/src/modeling_library/distributions/cauchy.jl
@@ -17,7 +17,7 @@ function logpdf_grad(::Cauchy, x::Real, x0::Real, gamma::Real)
     gamma_sq = gamma^2
     deriv_x0 =  2 * x_x0 / (gamma_sq + x_x0_sq)
     deriv_x = - deriv_x0
-    deriv_gamma = (x_x0_sq - gamma_sq) / (gamma * (gamma_sq + x_x0_sq)) 
+    deriv_gamma = (x_x0_sq - gamma_sq) / (gamma * (gamma_sq + x_x0_sq))
     (deriv_x, deriv_x0, deriv_gamma)
 end
 

--- a/src/modeling_library/map/backprop.jl
+++ b/src/modeling_library/map/backprop.jl
@@ -4,7 +4,7 @@ function choice_gradients(trace::VectorTrace{MapType,T,U}, selection::Selection,
     args = get_args(trace)
     n_args = length(args)
     len = length(args[1])
-    
+
     has_grads = has_argument_grads(trace.gen_fn.kernel)
     arg_grad = Vector(undef, n_args)
     for (i, has_grad) in enumerate(has_grads)
@@ -14,10 +14,10 @@ function choice_gradients(trace::VectorTrace{MapType,T,U}, selection::Selection,
             arg_grad[i] = nothing
         end
     end
-    
+
     value_choices = choicemap()
     gradient_choices = choicemap()
-    
+
     for key=1:len
         subtrace = trace.subtraces[key]
         sub_selection = selection[key]
@@ -40,7 +40,7 @@ function accumulate_param_gradients!(trace::VectorTrace{MapType,T,U}, retval_gra
     args = get_args(trace)
     n_args = length(args)
     len = length(args[1])
-    
+
     has_grads = has_argument_grads(trace.gen_fn.kernel)
     arg_grad = Vector(undef, n_args)
     for (i, has_grad) in enumerate(has_grads)
@@ -50,7 +50,7 @@ function accumulate_param_gradients!(trace::VectorTrace{MapType,T,U}, retval_gra
             arg_grad[i] = nothing
         end
     end
-    
+
     for key=1:len
         subtrace = trace.subtraces[key]
         kernel_retval_grad = (retval_grad == nothing) ? nothing : retval_grad[key]

--- a/src/modeling_library/map/generate.jl
+++ b/src/modeling_library/map/generate.jl
@@ -14,7 +14,7 @@ function process!(gen_fn::Map{T,U}, args::Tuple, choices::ChoiceMap,
     kernel_args = get_args_for_key(args, key)
     submap = get_submap(choices, key)
     (subtrace, weight) = generate(gen_fn.kernel, kernel_args, submap)
-    state.weight += weight 
+    state.weight += weight
     state.noise += project(subtrace, EmptySelection())
     state.num_nonempty += (isempty(get_choices(subtrace)) ? 0 : 1)
     state.score += get_score(subtrace)

--- a/src/modeling_library/map/generic_update.jl
+++ b/src/modeling_library/map/generic_update.jl
@@ -26,7 +26,7 @@ function process_all_retained!(gen_fn::Map{T,U}, args::Tuple, argdiffs::Tuple,
     if all(diff == NoChange() for diff in argdiffs)
 
         # only visit retained applications that were targeted
-        for key in retained_and_targeted 
+        for key in retained_and_targeted
             @assert key <= min(new_length, prev_length)
             process_retained!(gen_fn, args, choices_or_selection, key, kernel_no_change_argdiffs, state)
         end
@@ -53,7 +53,7 @@ function process_all_retained!(gen_fn::Map{T,U}, args::Tuple, argdiffs::Tuple,
             end
             process_retained!(gen_fn, args, choices_or_selection, key, kernel_argdiffs, state)
         end
-    
+
     end
 end
 

--- a/src/modeling_library/map/regenerate.jl
+++ b/src/modeling_library/map/regenerate.jl
@@ -91,12 +91,12 @@ function regenerate(trace::VectorTrace{MapType,T,U}, args::Tuple, argdiffs::Tupl
     process_all_retained!(gen_fn, args, argdiffs, selection,
                           prev_length, new_length, retained_and_selected, state)
     process_all_new!(gen_fn, args, selection, prev_length, new_length, state)
-    
+
     # retdiff
     retdiff = vector_compute_retdiff(state.updated_retdiffs, new_length, prev_length)
 
     # new trace
-    new_trace = VectorTrace{MapType,T,U}(gen_fn, state.subtraces, state.retval, args,  
+    new_trace = VectorTrace{MapType,T,U}(gen_fn, state.subtraces, state.retval, args,
         state.score, state.noise, new_length, state.num_nonempty)
 
     return (new_trace, state.weight, retdiff)

--- a/src/modeling_library/map/update.jl
+++ b/src/modeling_library/map/update.jl
@@ -84,12 +84,12 @@ function update(trace::VectorTrace{MapType,T,U}, args::Tuple, argdiffs::Tuple,
         trace.subtraces, trace.retval, prev_length, new_length)
     score = trace.score - score_decrement
     noise = trace.noise - noise_decrement
-    
+
     # handle retained and new applications
     state = MapUpdateState{T,U}(-score_decrement, score, noise,
                                      subtraces, retval, discard, num_nonempty,
                                      Dict{Int,Diff}())
-    process_all_retained!(gen_fn, args, argdiffs, choices, prev_length, new_length,    
+    process_all_retained!(gen_fn, args, argdiffs, choices, prev_length, new_length,
                           retained_and_constrained, state)
     process_all_new!(gen_fn, args, choices, prev_length, new_length, state)
 
@@ -97,7 +97,7 @@ function update(trace::VectorTrace{MapType,T,U}, args::Tuple, argdiffs::Tuple,
     retdiff = vector_compute_retdiff(state.updated_retdiffs, new_length, prev_length)
 
     # new trace
-    new_trace = VectorTrace{MapType,T,U}(gen_fn, state.subtraces, state.retval, args,  
+    new_trace = VectorTrace{MapType,T,U}(gen_fn, state.subtraces, state.retval, args,
         state.score, state.noise, new_length, state.num_nonempty)
 
     return (new_trace, state.weight, retdiff, discard)

--- a/src/modeling_library/recurse/recurse.jl
+++ b/src/modeling_library/recurse/recurse.jl
@@ -203,10 +203,10 @@ function simulate(gen_fn::Recurse{S,T,U,V,W,X,Y}, args::Tuple{U,Int}) where {S,T
     aggregation_traces = PersistentHashMap{Int,T}()
     score = 0.
     num_has_choices = 0
-    
+
     # production phase
     # does not matter in which order we visit (since children are inserted after parents)
-    prod_to_visit = Set{Int}([root_idx]) 
+    prod_to_visit = Set{Int}([root_idx])
     while !isempty(prod_to_visit)
         local subtrace::S
         local input::U
@@ -257,10 +257,10 @@ function generate(gen_fn::Recurse{S,T,U,V,W,X,Y}, args::Tuple{U,Int},
     weight = 0.
     score = 0.
     num_has_choices = 0
-    
+
     # production phase
     # does not matter in which order we visit (since children are inserted after parents)
-    prod_to_visit = Set{Int}([root_idx]) 
+    prod_to_visit = Set{Int}([root_idx])
     while !isempty(prod_to_visit)
         local subtrace::S
         local input::U
@@ -445,7 +445,7 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
     gen_fn = get_gen_fn(trace)
     (root_production_input::U, root_idx::Int) = new_args
     if root_idx != get_args(trace)[2]
-        error("Cannot change root_idx argument") 
+        error("Cannot change root_idx argument")
     end
 
     (root_argdiff::Diff,) = argdiffs
@@ -482,7 +482,7 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
     # only store for nodes that are retained
     # if a value is not present for a retained node, then the number of children of that node did not change
     idx_to_prev_num_children = Dict{Int,Int}()
-    
+
     # production phase
     production_retdiffs = Dict{Int,Diff}() # elements with no difference are ommitted
     while !isempty(prod_to_visit)
@@ -542,7 +542,7 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
             end
 
             if isa(subretdiff, ProductionDiff)
-            
+
                 # maybe mark existing children for processing, if they have a custom retdiff
                 # (otherwise they do not change)
                 for child_num in keys(subretdiff.children_diff.updated)
@@ -550,7 +550,7 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
                     child = get_child(cur, child_num, gen_fn.max_branch)
                     push!(prod_to_visit, child)
                 end
-    
+
                 # mark corresponding aggregation node for processing if v has
                 # changed, or if the number of children has changed
                 if subretdiff.value_diff != NoChange() || prev_num_children != new_num_children
@@ -636,7 +636,7 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
             elseif isempty(get_choices(prev_subtrace)) && !isempty(get_choices(subtrace))
                 num_has_choices += 1
             end
- 
+
             # take action based on our subretdiff
             if cur == root_idx
                 retdiff = subretdiff
@@ -665,13 +665,13 @@ function update(trace::RecurseTrace{S,T,U,V,W,X,Y},
             @assert cur != 1
             @assert get_parent(cur, gen_fn.max_branch) in agg_to_visit
         end
-        
+
     end
 
     new_trace = RecurseTrace{S,T,U,V,W,X,Y}(gen_fn,
         production_traces, aggregation_traces, gen_fn.max_branch,
         score, root_idx, num_has_choices)
-    
+
     return (new_trace, weight, retdiff, discard)
 end
 

--- a/src/modeling_library/unfold/backprop.jl
+++ b/src/modeling_library/unfold/backprop.jl
@@ -6,7 +6,7 @@ end
 function accumulate_param_gradients!(trace::VectorTrace{UnfoldType,T,U}, retval_grad) where {T,U}
     args = get_args(trace)
     (len, init_state, params) = unpack_args(args)
-    
+
     kernel_has_grads = has_argument_grads(trace.gen_fn.kernel)
     if kernel_has_grads[1]
         error("Cannot differentiate with respect to index in unfold")
@@ -16,7 +16,7 @@ function accumulate_param_gradients!(trace::VectorTrace{UnfoldType,T,U}, retval_
         error("Not implemented")
     end
     params_has_grad = kernel_has_grads[3:end]
- 
+
     params_grad = Vector(undef, length(params_has_grad))
     for (i, has_grad) in enumerate(params_has_grad)
         if has_grad
@@ -25,7 +25,7 @@ function accumulate_param_gradients!(trace::VectorTrace{UnfoldType,T,U}, retval_
             params_grad[i] = nothing
         end
     end
-    
+
     for key=1:len
         subtrace = trace.subtraces[key]
         kernel_retval_grad = (retval_grad == nothing) ? nothing : retval_grad[key]

--- a/src/modeling_library/unfold/generate.jl
+++ b/src/modeling_library/unfold/generate.jl
@@ -15,7 +15,7 @@ function process!(gen_fn::Unfold{T,U}, params::Tuple, choices::ChoiceMap,
     kernel_args = (key, state.state, params...)
     submap = get_submap(choices, key)
     (subtrace, weight) = generate(gen_fn.kernel, kernel_args, submap)
-    state.weight += weight 
+    state.weight += weight
     state.noise += project(subtrace, EmptySelection())
     state.num_nonempty += (isempty(get_choices(subtrace)) ? 0 : 1)
     state.score += get_score(subtrace)

--- a/src/modeling_library/unfold/regenerate.jl
+++ b/src/modeling_library/unfold/regenerate.jl
@@ -98,7 +98,7 @@ function regenerate(trace::VectorTrace{UnfoldType,T,U},
     # handle retained and new applications
     state = UnfoldRegenerateState{T,U}(init_state, -noise_decrement, score, noise,
         subtraces, retval, num_nonempty, Dict{Int,Diff}())
-    process_all_retained!(gen_fn, params, argdiffs, selection, prev_length, new_length,    
+    process_all_retained!(gen_fn, params, argdiffs, selection, prev_length, new_length,
                           retained_and_selected, state)
     process_all_new!(gen_fn, params, selection, prev_length, new_length, state)
 
@@ -106,7 +106,7 @@ function regenerate(trace::VectorTrace{UnfoldType,T,U},
     retdiff = vector_compute_retdiff(state.updated_retdiffs, new_length, prev_length)
 
     # new trace
-    new_trace = VectorTrace{UnfoldType,T,U}(gen_fn, state.subtraces, state.retval, args,  
+    new_trace = VectorTrace{UnfoldType,T,U}(gen_fn, state.subtraces, state.retval, args,
         state.score, state.noise, new_length, state.num_nonempty)
 
     (new_trace, state.weight, retdiff)

--- a/src/modeling_library/unfold/update.jl
+++ b/src/modeling_library/unfold/update.jl
@@ -98,7 +98,7 @@ function update(trace::VectorTrace{UnfoldType,T,U},
     # handle retained and new applications
     state = UnfoldUpdateState{T,U}(init_state, -score_decrement, score, noise,
         subtraces, retval, discard, num_nonempty, Dict{Int,Diff}())
-    process_all_retained!(gen_fn, params, argdiffs, choices, prev_length, new_length,    
+    process_all_retained!(gen_fn, params, argdiffs, choices, prev_length, new_length,
                           retained_and_constrained, state)
     process_all_new!(gen_fn, params, choices, prev_length, new_length, state)
 
@@ -106,7 +106,7 @@ function update(trace::VectorTrace{UnfoldType,T,U},
     retdiff = vector_compute_retdiff(state.updated_retdiffs, new_length, prev_length)
 
     # new trace
-    new_trace = VectorTrace{UnfoldType,T,U}(gen_fn, state.subtraces, state.retval, args,  
+    new_trace = VectorTrace{UnfoldType,T,U}(gen_fn, state.subtraces, state.retval, args,
         state.score, state.noise, new_length, state.num_nonempty)
 
     (new_trace, state.weight, retdiff, discard)

--- a/src/modeling_library/vector.jl
+++ b/src/modeling_library/vector.jl
@@ -110,7 +110,7 @@ function get_retained_and_constrained(constraints::ChoiceMap, prev_length::Int, 
             error("Constrained address does not exist: $key")
         end
     end
-    keys 
+    keys
 end
 
 function get_retained_and_selected(selection::EmptySelection, prev_length::Int, new_length::Int)
@@ -126,7 +126,7 @@ function get_retained_and_selected(selection::HierarchicalSelection, prev_length
             error("Selected address does not exist: $key")
         end
     end
-    keys 
+    keys
 end
 
 function get_retained_and_selected(selection::AllSelection, prev_length::Int, new_length::Int)

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -1,10 +1,10 @@
 @testset "static assignment to/from array" begin
     submap = StaticChoiceMap((a=1., b=[2., 2.5]),NamedTuple())
     outer = StaticChoiceMap((c=3.,), (d=submap, e=submap))
-    
+
     arr = to_array(outer, Float64)
     @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 2.5, 1.0, 2.0, 2.5]
-    
+
     choices = from_array(outer, Float64[1, 2, 3, 4, 5, 6, 7])
     @test choices[:c] == 1.0
     @test choices[:d => :a] == 2.0
@@ -29,10 +29,10 @@ end
     set_value!(submap, :b, [2., 2.5])
     set_submap!(outer, :d, submap)
     set_submap!(outer, :e, submap)
-    
+
     arr = to_array(outer, Float64)
     @test to_array(outer, Float64) == Float64[3.0, 1.0, 2.0, 2.5, 1.0, 2.0, 2.5]
-    
+
     choices = from_array(outer, Float64[1, 2, 3, 4, 5, 6, 7])
     @test choices[:c] == 1.0
     @test choices[:d => :a] == 2.0
@@ -353,7 +353,7 @@ end
 
     c = choicemap((:a, 1), (:b, 2))
 
-    filtered = get_selected(c, select(:a))    
+    filtered = get_selected(c, select(:a))
     @test filtered[:a] == 1
     @test !has_value(filtered, :b)
 

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -54,7 +54,7 @@ end
     end
 
     @testset "getindex" begin
-    
+
     v = [1, 2, 3]
     i = Diffed(2, UnknownChange())
     @test strip_diff(v[i]) == 2

--- a/test/inference/elliptical_slice.jl
+++ b/test/inference/elliptical_slice.jl
@@ -6,7 +6,7 @@
         x = @trace(mvnormal(mu, cov), :x)
         y = @trace(mvnormal(x, [0.01 0.; 0. 0.01]), :y)
     end
-    
+
     # smoke test
     trace, = generate(foo, (), choicemap((:y, [1., 1.])))
     trace = elliptical_slice(trace, :x, mu, cov)

--- a/test/inference/importance_sampling.jl
+++ b/test/inference/importance_sampling.jl
@@ -12,7 +12,7 @@
     y = 2.
     observations = choicemap()
     set_value!(observations, :y, y)
-    
+
     n = 4
 
     (traces, log_weights, lml_est) = importance_sampling(model, (), observations, n)

--- a/test/inference/particle_filter.jl
+++ b/test/inference/particle_filter.jl
@@ -6,13 +6,13 @@ function hmm_forward_alg(prior::Vector{Float64},
     for i=2:length(emissions)
 
         # p(z_{i-1} , y_{i-1} | y_{1:i-2}) for each z_{i-1}
-        prev_posterior = alpha .* emission_dists[emissions[i-1], :] 
+        prev_posterior = alpha .* emission_dists[emissions[i-1], :]
 
         # p(y_{i-1} | y_{1:i-2})
-        denom = sum(prev_posterior) 
+        denom = sum(prev_posterior)
 
         # p(z_{i-1} | y_{1:i-1})
-        prev_posterior = prev_posterior / denom 
+        prev_posterior = prev_posterior / denom
 
         # p(z_i | y_{1:i-1})
         alpha = transition_dists * prev_posterior
@@ -20,8 +20,8 @@ function hmm_forward_alg(prior::Vector{Float64},
         # p(y_{1:i-1})
         marg_lik *= denom
     end
-    prev_posterior = alpha .* emission_dists[emissions[end], :] 
-    denom = sum(prev_posterior) 
+    prev_posterior = alpha .* emission_dists[emissions[end], :]
+    denom = sum(prev_posterior)
     marg_lik *= denom
     marg_lik
 end
@@ -44,7 +44,7 @@ end
     expected_marg_lik += prior[2] * transition_dists[2, 2] * emission_dists[obs[1], 2] * emission_dists[obs[2], 2]
     actual_marg_lik = hmm_forward_alg(prior, emission_dists, transition_dists, obs)
     @test isapprox(actual_marg_lik, expected_marg_lik)
-    
+
 end
 
 @testset "particle filtering" begin
@@ -113,7 +113,7 @@ end
         init_proposal, init_proposal_args, num_particles)
 
     # do particle filter steps
-    
+
     @gen function step_proposal(prev_trace, T::Int, x::Float64)
         @assert T > 1
         choices = get_choices(prev_trace)
@@ -135,7 +135,7 @@ end
         particle_filter_step!(state, new_args, argdiffs, observations,
             step_proposal, proposal_args)
     end
-    
+
     # check log marginal likelihood estimate
     expected_log_ml = log(hmm_forward_alg(prior, emission_dists, transition_dists, obs_x))
     actual_log_ml_est = log_ml_estimate(state)
@@ -151,7 +151,7 @@ end
     # initialize the particle filter
     init_observations = choicemap((:x_init, obs_x[1]))
     state = initialize_particle_filter(model, (1,), init_observations, num_particles)
-    
+
     # do steps
     argdiffs = (UnknownChange(),) # the length may change
     for T=2:length(obs_x)

--- a/test/inference/train.jl
+++ b/test/inference/train.jl
@@ -63,7 +63,7 @@
     # theta1 = 0.0
     # theta2 -> inf (prob_y -> 1)
     # theta3 -> -inf (prob_y -> 0)
-    
+
     init_param!(student, :theta1, 0.)
     init_param!(student, :theta2, 0.)
     init_param!(student, :theta3, 0.)
@@ -99,7 +99,7 @@
             (incr, _) = assess(student, inputs[i], constraints[i])
             lpdf_neg += incr
         end
-    
+
         expected = (lpdf_pos - lpdf_neg) / (2 * dx)
         @test isapprox(actual, expected, atol=1e-4)
 
@@ -124,13 +124,13 @@ end
 
 
 @testset "lecture!" begin
-    
+
     Random.seed!(1)
 
     # simple p
     @gen function p()
         z = @trace(normal(0., 1.), :z)
-        x = @trace(normal(z + 2., 0.3), :x) 
+        x = @trace(normal(z + 2., 0.3), :x)
         return x
     end
 

--- a/test/modeling_library/custom_determ.jl
+++ b/test/modeling_library/custom_determ.jl
@@ -66,7 +66,7 @@
             gen_fn::MyDeterministicGF, state, args, retgrad, scaler)
         gen_fn.my_grad += (retgrad * state.sum) * scaler
         arr_gradient = fill(retgrad * state.my_param, length(state.prev))
-        (arr_gradient,)        
+        (arr_gradient,)
     end
 
     # simulate
@@ -111,7 +111,7 @@
 
     # choice gradients
     trace = simulate(MyDeterministicGF(), ([1, 2, 3],))
-    arg_grads, _, _ = choice_gradients(trace, EmptySelection(), 2.) 
+    arg_grads, _, _ = choice_gradients(trace, EmptySelection(), 2.)
     @test arg_grads[1] == [2., 2., 2.]
 
     # accumulate parameter gradients
@@ -131,9 +131,9 @@ end
     Gen.gradient(::CustomPlus, args, retval, retgrad) = (retgrad, retgrad)
     custom_plus = CustomPlus()
     trace = simulate(custom_plus, (1., 2.))
-    
+
     # choice gradients
-    arg_grads, _, _ = choice_gradients(trace, EmptySelection(), 2.) 
+    arg_grads, _, _ = choice_gradients(trace, EmptySelection(), 2.)
     @test arg_grads == (2., 2.)
 
     # accumulate parameter gradients
@@ -147,17 +147,17 @@ end
         prev_arr::Vector{Float64}
         sum::Float64
     end
-    
+
     struct MySum <: CustomUpdateGF{Float64,MyState} end
     mysum = MySum()
-    
+
     function Gen.apply_with_state(::MySum, args)
         arr = args[1]
         s = sum(arr)
         state = MyState(arr, s)
         (s, state)
     end
-    
+
     function Gen.update_with_state(::MySum, state, args, argdiffs::Tuple{VectorDiff})
         arr = args[1]
         prev_sum = state.sum
@@ -176,7 +176,7 @@ end
         state = MyState(arr, retval)
         (state, retval, UnknownChange())
     end
-    
+
     Gen.num_args(::MySum) = 1
 
     # simulate

--- a/test/modeling_library/map.jl
+++ b/test/modeling_library/map.jl
@@ -1,5 +1,5 @@
 @testset "map combinator" begin
-    
+
     @gen (grad) function foo((grad)(x::Float64), (grad)(y::Float64))
         @param std::Float64
         z = @trace(normal(x + y, std), :z)

--- a/test/modeling_library/recurse.jl
+++ b/test/modeling_library/recurse.jl
@@ -12,7 +12,7 @@ using Gen: get_child, get_child_num, get_parent
     @test get_parent(2, 1) == 1
     @test get_parent(3, 1) == 2
     @test get_parent(4, 1) == 3
-    
+
     # max_branch = 2
     @test get_child(1, 1, 2) == 2
     @test get_child(1, 2, 2) == 3
@@ -83,7 +83,7 @@ end
 
         return Production(production_rule, [nothing for _=1:num_children])
     end
-    
+
     @gen function pcfg_aggregation(production_rule::Int, child_outputs::Vector{String})
         prefix = @trace(bernoulli(0.4), :prefix) ? "." : "-"
         local str::String
@@ -149,7 +149,7 @@ end
         push!(strings, get_retval(trace))
     end
     test_strings(strings)
-    
+
     # apply generate to a complete choice map that produces "(.b(.a(.b(-bb)b)a)b)"
     # sequence of production rules: 2 -> 1 -> 2 -> 4
     expected_weight = log(0.26) + log(0.24) + log(0.26) + log(0.27) + log(0.4) + log(0.4) + log(0.4) + log(0.6)

--- a/test/modeling_library/unfold.jl
+++ b/test/modeling_library/unfold.jl
@@ -489,7 +489,7 @@
         end
 
         foo = Unfold(kernel)
-   
+
         std = 1.
         set_param!(kernel, :std, std)
 

--- a/test/static_ir/static_ir.jl
+++ b/test/static_ir/static_ir.jl
@@ -299,7 +299,7 @@ end
         #out = @trace(normal(c, 1), :out)
         #return out
     #end
-    
+
     # foo
     builder = StaticIRBuilder()
     mu_a = add_argument_node!(builder, name=:mu_a, typ=:Float64, compute_grad=true)


### PR DESCRIPTION
This pull request contains no functional changes. It removes trailing spaces from .jl files:

    $ find . -iname '*.jl' | xargs sed -i 's/[ \t]*$//'