### PR TITLE
add check for relatively common choice map constructor typo

### DIFF
--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -625,7 +625,11 @@ end
 
 function DynamicChoiceMap(tuples...)
     choices = DynamicChoiceMap()
-    for (addr, value) in tuples
+    for tuple in tuples
+        if length(tuple) != 2
+            error("Constructor accepts tuples of the form (address, value) only")
+        end
+        (addr, value) = tuple
         choices[addr] = value
     end
     choices

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -367,3 +367,9 @@ end
     @test filtered[:x => :y] == 1
     @test !has_value(filtered, :x => :z)
 end
+
+@testset "invalid choice map constructor" begin
+    threw = false
+    try c = choicemap((:a, 1, :b, 2)) catch Exception threw = true end
+    @test threw
+end


### PR DESCRIPTION
Common typos include writing `choicemap((:a, 1, :b, 2))` or `choicemap(:a, 1, :b, 2)` in place of `choicemap((:a, 1), (:b, 2))` or to otherwise miss-parenthesize the expression, but previously, some of these bugs would not cause errors. This PR adds a check that catches more of these errors.