### PR TITLE
Support AD-safe type checking in dynamic @gen functions

### DIFF
--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -142,13 +142,14 @@ function parse_gen_function(ast, annotations, __module__)
     ast = MacroTools.longdef(ast)
     def = MacroTools.splitdef(ast)
     name = def[:name]
-    args = def[:args] .|> parse_arg .|> a -> resolve_grad_arg(a, __module__)
+    args = map(parse_arg, def[:args])
     body = preprocess_body(def[:body], __module__)
     return_type = get(def, :rtype, :Any)
     static = DSL_STATIC_ANNOTATION in annotations
     if static
         make_static_gen_function(name, args, body, return_type, annotations)
     else
+        args = map(a -> resolve_grad_arg(a, __module__), args)
         make_dynamic_gen_function(name, args, body, return_type, annotations)
     end
 end

--- a/src/dsl/dynamic.jl
+++ b/src/dsl/dynamic.jl
@@ -2,12 +2,12 @@ const DYNAMIC_DSL_TRACE = Symbol("@trace")
 
 "Convert Argument structs to ASTs."
 function arg_to_ast(arg::Argument)
-    ast = esc(arg.name)
+    ast = Expr(:(::), esc(arg.name), esc(arg.typ))
     if (arg.default != nothing)
         default = something(arg.default)
         ast = Expr(:kw, ast, esc(default))
     end
-    ast
+    return ast
 end
 
 "Escape argument defaults (if present)."
@@ -41,8 +41,8 @@ function make_dynamic_gen_function(name, args, body, return_type, annotations)
         esc(body))
     arg_types = map((arg) -> esc(arg.typ), args)
     arg_defaults = map(escape_default, args)
-    has_argument_grads = map(
-        (arg) -> (DSL_ARG_GRAD_ANNOTATION in arg.annotations), args)
+    has_argument_grads =
+        map((arg) -> (DSL_ARG_GRAD_ANNOTATION in arg.annotations), args)
     accepts_output_grad = DSL_RET_GRAD_ANNOTATION in annotations
 
     quote

--- a/test/inference/particle_filter.jl
+++ b/test/inference/particle_filter.jl
@@ -31,7 +31,7 @@ end
     # test the hmm_forward_alg on a hand-calculated example
     prior = [0.4, 0.6]
     emission_dists = [0.1 0.9; 0.7 0.3]'
-    transition_dists = [0.5 0.5; 0.2 0.8']
+    transition_dists = [0.5 0.5; 0.2 0.8]'
     obs = [2, 1]
     expected_marg_lik = 0.
     # z = [1, 1]
@@ -114,7 +114,7 @@ end
 
     # do particle filter steps
 
-    @gen function step_proposal(prev_trace, T::Int, x::Float64)
+    @gen function step_proposal(prev_trace, T::Int, x::Int)
         @assert T > 1
         choices = get_choices(prev_trace)
         if T > 2


### PR DESCRIPTION
This PR ensures that type annotations in dynamic `@gen` function definitions get propagated to the underlying `julia_function`. This should help prevent unexpected errors or behavior due to `@gen` functions accepting the wrong type. For example, instead of the behavior documented in #255 where re-defined `@gen` functions continued to work on the old types, they will throw a method error:

```
julia> @gen foo(x::Int) = y ~ uniform_discrete(1, x);
julia> foo(5)
3
julia> @gen foo(x::Float64) = y ~ normal(x, 1);
julia> foo(5)
ERROR: MethodError: no method matching ##foo#449(::Gen.GFProposeState, ::Int64)
julia> foo(5.0)
5.632113778420875
```

If we ever decide to support multiple-dispatch as requested in #255, this PR also helps lay the groundwork for that, by ensuring the inner Julia methods do not automatically accept every argument type.

I previously tried to implement this feature when adding support for optional arguments in #195, but ran into AD errors due to the [restrictions on ReverseDiff](http://www.juliadiff.org/ReverseDiff.jl/limits/). This implementation is AD-safe , because it automatically promotes the types of `(grad)`-annotated arguments to `Real` or `AbstractArray{<:Real}`.

Note that loose type-checking [i.e., type conversion via `convert`] is already performed for static `@gen` functions during construction of the `StaticTrace`.