### PR TITLE
Fixed small naming issue with the selection test sets.

### DIFF
--- a/test/selection.jl
+++ b/test/selection.jl
@@ -1,4 +1,4 @@
-@testset begin "dynamic selection"
+@testset "dynamic selection" begin
 
     s = select(:x, :y => :z, :y => :w)
 
@@ -33,7 +33,7 @@
     @test !(:x in selection)
 end
 
-@testset begin "all selection"
+@testset "all selection" begin
 
     s = selectall()
 
@@ -46,7 +46,7 @@ end
     @test s[:x => :y] == AllSelection()
 end
 
-@testset begin "complement selection"
+@testset "complement selection" begin
 
     @test !(:x in complement(selectall()))
     @test :x in complement(select())


### PR DESCRIPTION
For whatever reason, the test sets for `Selection` functionality weren't named properly (the test-set names were accidentally placed after the `begin` keyword, instead of before). This is a small PR to address that.