### PR TITLE
Fix overflows in normal distribution logpdf calculation

### DIFF
--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -67,7 +67,7 @@ function logpdf(::BroadcastedNormal,
     z = (x .- mu) ./ std
     var = std .* std
     diff = x .- mu
-    sum(- (abs2.(z) .+ log(2π)) / 2 - log.(std))
+    sum(- (abs2.(z) .+ log(2π)) / 2 .- log.(std))
 end
 
 function logpdf_grad(::Normal, x::Real, mu::Real, std::Real)
@@ -89,7 +89,7 @@ function logpdf_grad(::BroadcastedNormal,
     diff = mu .- x
     deriv_x = sum(- z ./ std)
     deriv_mu = -deriv_x
-    deriv_std = sum(-1. ./ std .+ abs2(z) ./ std)
+    deriv_std = sum(-1. ./ std .+ abs2.(z) ./ std)
     (deriv_x, deriv_mu, deriv_std)
 end
 

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -95,8 +95,8 @@ end
     x = normal(0, 1)
 
     # does not overflow
-    @test logpdf(normal, 10000000000000, 0, 1) == -5e25
-    @test logpdf_grad(normal, 10000000000000, 0, 1) == (-1e13, 1e13, 1e26)
+    @test logpdf(normal, 1e13, 0, 1) == -5e25
+    @test logpdf_grad(normal, 1e13, 0, 1) == (-1e13, 1e13, 1e26)
 
     # logpdf_grad
     f = (x, mu, std) -> logpdf(normal, x, mu, std)

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -94,6 +94,10 @@ end
     # random
     x = normal(0, 1)
 
+    # does not overflow
+    @test logpdf(normal, 10000000000000, 0, 1) == -5e25
+    @test logpdf_grad(normal, 10000000000000, 0, 1) == (-1e13, 1e13, 1e26)
+
     # logpdf_grad
     f = (x, mu, std) -> logpdf(normal, x, mu, std)
     args = (0.4, 0.2, 0.3)


### PR DESCRIPTION
`logpdf` was returning positive numbers for large differences between `x` and `mu` (large `std` overflowed too).

Checked against Distributions.jl, but please make sure it is correct. Another reason for https://github.com/probcomp/Gen.jl/issues/244