### PR TITLE
Remove overhead during untraced execution of dynamic @gen functions.

### DIFF
--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -45,13 +45,17 @@ end
 
 accepts_output_grad(gen_fn::DynamicDSLFunction) = gen_fn.accepts_output_grad
 
-function (gen_fn::DynamicDSLFunction)(args...)
-    (_, _, retval) = propose(gen_fn, args)
-    retval
+mutable struct GFUntracedState
+    params::Dict{Symbol,Any}
 end
 
-function exec(gf::DynamicDSLFunction, state, args::Tuple)
-    gf.julia_function(state, args...)
+function (gen_fn::DynamicDSLFunction)(args...)
+    state = GFUntracedState(gen_fn.params)
+    gen_fn.julia_function(state, args...)
+end
+
+function exec(gen_fn::DynamicDSLFunction, state, args::Tuple)
+    gen_fn.julia_function(state, args...)
 end
 
 # whether there is a gradient of score with respect to each argument
@@ -75,6 +79,13 @@ function dynamic_trace_impl(expr::Expr)
         return Expr(:call, GlobalRef(@__MODULE__, :splice), state, fn, args)
     end
 end
+
+# Defaults for untraced execution
+@inline traceat(state::GFUntracedState, gen_fn::GenerativeFunction{T,U}, args, key) where {T,U} =
+    gen_fn(args...)
+
+@inline traceat(state::GFUntracedState, dist::Distribution{T}, args, key) where {T} =
+    random(dist, args...)
 
 ########################
 # trainable parameters #

--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -81,10 +81,10 @@ function dynamic_trace_impl(expr::Expr)
 end
 
 # Defaults for untraced execution
-@inline traceat(state::GFUntracedState, gen_fn::GenerativeFunction{T,U}, args, key) where {T,U} =
+@inline traceat(state::GFUntracedState, gen_fn::GenerativeFunction, args, key) =
     gen_fn(args...)
 
-@inline traceat(state::GFUntracedState, dist::Distribution{T}, args, key) where {T} =
+@inline traceat(state::GFUntracedState, dist::Distribution, args, key) =
     random(dist, args...)
 
 ########################


### PR DESCRIPTION
I noticed while benchmarking `Genify.jl` that untraced execution of any `DynamicDSLFunction` incurs a 20x overhead, because it's calling `propose` under the hood, collecting trace-related metadata that is then simply discarded. This PR removes that overhead by simply forwarding the call to the embedded Julia function. `traceat` will just directly call any nested generative function, and sample from any distribution without recording weights, etc.

An example model in plain Julia, and in Gen:
```julia
function model()
    mean = normal(0,1)
    data = [normal(mean, 1) for i in 1:1000]
end

@gen function genmodel()
    mean ~ normal(0, 1)
    data = [{(:data, i)} ~ normal(mean, 1) for i in 1:1000]
end
```

The original Julia model is very fast:
```julia
julia> @btime model();
  10.899 μs (1 allocation: 7.94 KiB)
```

Before this PR, the Gen model is ~25x slower and allocates a lot more memory, giving a sense of how much overhead `propose` is adding:
```julia
julia> @btime genmodel();
  253.499 μs (4680 allocations: 281.34 KiB)
```

With this PR, almost all the overhead is gone:
```julia
julia> @btime genmodel();
  10.499 μs (4 allocations: 8.02 KiB)
```

I think this will be useful whenever we write models or algorithms we aren't always doing inference over, and also to make benchmarking future improvements to the dynamic modeling language easier (because we don't have to rewrite the function in plain Julia just to test things out). When optimizing for performance, it'll also help developers isolate how much overhead is coming from Gen.