### PR TITLE
Note in docs that definitions of `(static)` generative functions and calls to `@load_generated_functions()` are supported as top-level expressions only

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -426,7 +426,10 @@ This will produce a file `test.pdf` in the current working directory containing 
 
 ### Restrictions
 
-In order to be able to construct the static graph, Gen restricts the permitted syntax that can be used in functions annotated with `static`.
+First, the definition of a `(static)` generative function is always expected to occur as a [top-level definition](https://docs.julialang.org/en/v1/manual/modules/) (aka global variable); usage in non–top-level scopes is unsupported and may result in incorrect behavior.
+Recall also that the macro [`@load_generated_functions`](@ref) is expected to be called as a top-level expression only.
+
+Next, in order to be able to construct the static graph, Gen restricts the permitted syntax that can be used in functions annotated with `static`.
 In particular, each statement in the body must be one of the following:
 
 - A `@param` statement specifying any [Trainable parameters](@ref), e.g.:

--- a/src/Gen.jl
+++ b/src/Gen.jl
@@ -21,6 +21,10 @@ end
 
 Permit use of generative functions written in the static modeling language up
 to this point. Functions are loaded into the calling module.
+
+This macro is intended to be called as a
+[top-level expression](https://docs.julialang.org/en/v1/manual/modules/)
+only; use in non–top-level scopes may result in incorrect behavior.
 """
 macro load_generated_functions()
     for function_defn in generated_functions


### PR DESCRIPTION
See [thread](https://probcomp.slack.com/archives/C5T7HNLRY/p1602713555118100?thread_ts=1602701467.114500&cid=C5T7HNLRY).