### PR TITLE
Fix test case with wrong input type.

### DIFF
--- a/test/dsl/dynamic_dsl.jl
+++ b/test/dsl/dynamic_dsl.jl
@@ -25,9 +25,9 @@ end
 
     @test baz(5) == 5
 
-    @gen (grad) oneliner(x::Float64, (grad)(y::Float64=5)) = x+y
+    @gen (grad) oneliner(x::Float64, (grad)(y::Float64=5.0)) = x+y
 
-    @test oneliner(5) == 10
+    @test oneliner(5.0) == 10.0
 end
 
 @testset "return type" begin


### PR DESCRIPTION
Now that Gen's dynamic modeling language type-checks function arguments, one of the test cases ended up erroring because it passed in an `Int` when a `Float64` was expected. This PR fixes the error.