### PR TITLE
Fix splicing of generative functions in untraced calls

### DIFF
--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -87,6 +87,9 @@ end
 @inline traceat(state::GFUntracedState, dist::Distribution, args, key) =
     random(dist, args...)
 
+@inline splice(state::GFUntracedState, gen_fn::DynamicDSLFunction, args::Tuple) =
+    gen_fn(args...)
+
 ########################
 # trainable parameters #
 ########################

--- a/test/dsl/dynamic_dsl.jl
+++ b/test/dsl/dynamic_dsl.jl
@@ -28,6 +28,11 @@ end
     @gen (grad) oneliner(x::Float64, (grad)(y::Float64=5.0)) = x+y
 
     @test oneliner(5.0) == 10.0
+
+    @gen outer() = @trace(inner())
+    @gen inner() = 5.0
+
+    @test outer() == 5.0
 end
 
 @testset "return type" begin


### PR DESCRIPTION
Addresses #345 by adding an additional method for `splice`. Also adds a test case so we don't miss this in the future.