### PR TITLE
Add `has_submap`  method for ChoiceMaps (#124)

### DIFF
--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -31,6 +31,13 @@ no value exists. A syntactic sugar is `Base.getindex`:
 function get_value end
 
 """
+    has_submap(choices::ChoiceMap, addr)
+
+Return true if there is a non-empty sub-assignment at the given address.
+"""
+function has_submap end
+
+"""
     key_submap_iterable = get_submaps_shallow(choices::ChoiceMap)
 
 Return an iterable collection of tuples `(key, submap::ChoiceMap)` for each top-level key
@@ -69,6 +76,8 @@ function Base.isempty(::ChoiceMap)
     true
 end
 
+
+@inline has_submap(choices::ChoiceMap, addr) = !has_value(choices, addr) && !isempty(get_submap(choices, addr))
 @inline get_submap(choices::ChoiceMap, addr) = EmptyChoiceMap()
 @inline has_value(choices::ChoiceMap, addr) = false
 @inline get_value(choices::ChoiceMap, addr) = throw(KeyError(addr))
@@ -323,6 +332,7 @@ end
 
 export ChoiceMap
 export get_address_schema
+export has_submap
 export get_submap
 export get_value
 export has_value

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -267,16 +267,20 @@ end
     # overwrite value with a submap
     choices = choicemap()
     choices[:x] = 1
+    @test has_value(choices, :x)
+    @test !has_submap(choices, :x)
     submap = choicemap(); submap[:y] = 2
     set_submap!(choices, :x, submap)
     @test !has_value(choices, :x)
     @test !isempty(get_submap(choices, :x))
+    @test has_submap(choices, :x)
 
     # overwrite subassignment with a value
     choices = choicemap()
     choices[:x => :y] = 1
     choices[:x] = 2
     threw = false
+    @test !has_submap(choices, :x)
     try get_submap(choices, :x) catch KeyError threw = true end
     @test threw
     @test choices[:x] == 2
@@ -284,6 +288,8 @@ end
     # overwrite subassignment with a subassignment
     choices = choicemap()
     choices[:x => :y] = 1
+    @test has_submap(choices, :x)
+    @test !has_submap(choices, :x => :y)
     submap = choicemap(); submap[:z] = 2
     set_submap!(choices, :x,  submap)
     @test !isempty(get_submap(choices, :x))


### PR DESCRIPTION
This PR implements the `has_submap` method that Ben suggested adding in #124.

The implementation is slightly different from what he suggested. A ChoiceMap has a submap at an address if:

* It does not have a value at that address, and
* `get_submap(choices, addr)` returns a non-empty ChoiceMap.

This accords with the spec of `get_submap`, which is supposed to throw an error if it finds a value at the given address, and return an empty ChoiceMap if there is no submap at the address.

[That said, I've sometimes seen "orphan" empty choice maps show up when printing, which makes me think that at least some kinds of choicemap implement `get_submaps_shallow` to return both empty and non-empty submaps (the docs say to return only the non-empty ones).]