### PR TITLE
Pretty print for static IR

### DIFF
--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -19,6 +19,9 @@ struct DynamicDSLFunction{T} <: GenerativeFunction{T,DynamicDSLTrace}
     accepts_output_grad::Bool
 end
 
+Base.nameof(gen_fn::DynamicDSLFunction) =
+    nameof(gen_fn.julia_function)
+
 function DynamicDSLFunction(arg_types::Vector{Type},
                      arg_defaults::Vector{Union{Some{Any},Nothing}},
                      julia_function::Function,

--- a/src/dynamic/dynamic.jl
+++ b/src/dynamic/dynamic.jl
@@ -19,9 +19,6 @@ struct DynamicDSLFunction{T} <: GenerativeFunction{T,DynamicDSLTrace}
     accepts_output_grad::Bool
 end
 
-Base.nameof(gen_fn::DynamicDSLFunction) =
-    nameof(gen_fn.julia_function)
-
 function DynamicDSLFunction(arg_types::Vector{Type},
                      arg_defaults::Vector{Union{Some{Any},Nothing}},
                      julia_function::Function,

--- a/src/static_ir/print_ir.jl
+++ b/src/static_ir/print_ir.jl
@@ -23,7 +23,7 @@ end
 
 function print_ir(io::IO, node::GenerativeFunctionCallNode)
     inputs = join((string(i.name) for i in node.inputs), ", ")
-    gen_fn_name = nameof(node.generative_function)
+    gen_fn_name = ir_name(node.generative_function)
     print(io, "$(node.name) = @trace($(gen_fn_name)($inputs), :$(node.addr))")
 end
 
@@ -31,3 +31,6 @@ function print_ir(io::IO, node::RandomChoiceNode)
     inputs = join((string(i.name) for i in node.inputs), ", ")
     print(io, "$(node.name) = @trace($(node.dist)($inputs), :$(node.addr))")
 end
+
+ir_name(fn::GenerativeFunction) = nameof(typeof(fn))
+ir_name(fn::DynamicDSLFunction) = nameof(fn.julia_function)

--- a/src/static_ir/print_ir.jl
+++ b/src/static_ir/print_ir.jl
@@ -1,0 +1,33 @@
+Base.show(io::IO, ::MIME"text/plain", ir::StaticIR) =
+    print_ir(io, ir)
+
+function print_ir(io::IO, ir::StaticIR)
+    println(io, "== Static IR ==")
+    args = join((string(arg.name) for arg in ir.arg_nodes), ", ")
+    println(io, "Arguments: ($args)")
+    for node in ir.nodes
+        node in ir.arg_nodes && continue
+        print(io, "  "); print_ir(io, node); println(io)
+    end
+    print(io, "  return $(ir.return_node.name)")
+end
+
+function print_ir(io::IO, node::TrainableParameterNode)
+    print(io, "@param $(node.name)::$(node.typ)")
+end
+
+function print_ir(io::IO, node::JuliaNode)
+    inputs = join((string(i.name) for i in node.inputs), ", ")
+    print(io, "$(node.name) = $(node.fn)($inputs)")
+end
+
+function print_ir(io::IO, node::GenerativeFunctionCallNode)
+    inputs = join((string(i.name) for i in node.inputs), ", ")
+    gen_fn_name = nameof(node.generative_function)
+    print(io, "$(node.name) = @trace($(gen_fn_name)($inputs), :$(node.addr))")
+end
+
+function print_ir(io::IO, node::RandomChoiceNode)
+    inputs = join((string(i.name) for i in node.inputs), ", ")
+    print(io, "$(node.name) = @trace($(node.dist)($inputs), :$(node.addr))")
+end

--- a/src/static_ir/static_ir.jl
+++ b/src/static_ir/static_ir.jl
@@ -27,6 +27,9 @@ Most generative function interface methods are generated from the intermediate r
 """
 abstract type StaticIRGenerativeFunction{T,U} <: GenerativeFunction{T,U} end
 
+Base.nameof(gen_fn::StaticIRGenerativeFunction) =
+    nameof(type_of(gen_fn))
+
 function get_ir end
 function get_gen_fn_type end
 function get_options end
@@ -52,6 +55,7 @@ function generate_generative_function(ir::StaticIR, name::Symbol, options::Stati
             params::Dict{Symbol,Any}
         end
         (gen_fn::$gen_fn_type_name)(args...) = $(GlobalRef(Gen, :propose))(gen_fn, args)[3]
+        $(GlobalRef(Gen, :get_ir))(::$gen_fn_type_name) = $(QuoteNode(ir))
         $(GlobalRef(Gen, :get_ir))(::Type{$gen_fn_type_name}) = $(QuoteNode(ir))
         $(GlobalRef(Gen, :get_trace_type))(::Type{$gen_fn_type_name}) = $trace_struct_name
         $(GlobalRef(Gen, :has_argument_grads))(::$gen_fn_type_name) = $(QuoteNode(has_argument_grads))
@@ -63,6 +67,7 @@ function generate_generative_function(ir::StaticIR, name::Symbol, options::Stati
     Expr(:block, trace_defns, gen_fn_defn, Expr(:call, gen_fn_type_name, :(Dict{Symbol,Any}()), :(Dict{Symbol,Any}())))
 end
 
+include("print_ir.jl")
 include("render_ir.jl")
 
 ###########################

--- a/src/static_ir/static_ir.jl
+++ b/src/static_ir/static_ir.jl
@@ -27,9 +27,6 @@ Most generative function interface methods are generated from the intermediate r
 """
 abstract type StaticIRGenerativeFunction{T,U} <: GenerativeFunction{T,U} end
 
-Base.nameof(gen_fn::StaticIRGenerativeFunction) =
-    nameof(type_of(gen_fn))
-
 function get_ir end
 function get_gen_fn_type end
 function get_options end

--- a/test/static_ir/static_ir.jl
+++ b/test/static_ir/static_ir.jl
@@ -22,6 +22,7 @@ z = add_julia_node!(builder, (u, v) -> u + v, inputs=[u, v], name=:z)
 set_return_node!(builder, z)
 ir = build_ir(builder)
 bar = eval(generate_generative_function(ir, :bar, track_diffs=false, cache_julia_nodes=false))
+@test occursin("== Static IR ==", repr("text/plain", ir))
 
 #@gen (static, nojuliacache) function foo(a, b)
     #@param theta::Float64
@@ -45,6 +46,7 @@ w = add_julia_node!(builder, (z, a, theta) -> z + 1 + a + theta, inputs=[z, a, t
 set_return_node!(builder, w)
 ir = build_ir(builder)
 foo = eval(generate_generative_function(ir, :foo, track_diffs=false, cache_julia_nodes=false))
+@test occursin("== Static IR ==", repr("text/plain", ir))
 
 theta_val = rand()
 set_param!(foo, :theta, theta_val)
@@ -58,6 +60,7 @@ one = add_constant_node!(builder, 2)
 set_return_node!(builder, one)
 ir = build_ir(builder)
 const_fn = eval(generate_generative_function(ir, :const_fn, track_diffs=false, cache_julia_nodes=false))
+@test occursin("== Static IR ==", repr("text/plain", ir))
 
 Gen.load_generated_functions()
 


### PR DESCRIPTION
Given a static generative function like this:
```julia
@gen (static) function datum(x::Float64, (grad)(params::Params))
    is_outlier = @trace(bernoulli(params.prob_outlier), :z)
    std = is_outlier ? params.outlier_std : params.inlier_std
    y = @trace(normal(x * params.slope + params.intercept, std), :y)
    return y
end
```

This PR makes it so that the IR is automatically pretty-printed like this:
```julia
julia> Gen.get_ir(datum)
== Static IR ==
Arguments: (x, params)
  ##.#445 = #15(params)
  ##z#442 = @trace(Gen.Bernoulli()(##.#445), :z)
  std = #16(params, ##z#442)
  ##call#451 = #17(params, x)
  ##y#448 = @trace(Gen.Normal()(##call#451, std), :y)
  return ##y#448
```

Should come in handy for debugging domain-specific compilers to IR, as well as any future improvements made to the IR or static function compilation.