### PR TITLE
Fix inconsistent variable name

### DIFF
--- a/docs/src/ref/mcmc.md
+++ b/docs/src/ref/mcmc.md
@@ -277,19 +277,19 @@ m = sqrt(m1 * m2)
 ```
 However, there are many combinations of `m1` and `m2` that have the same geometric mean.
 In other words, the geometric mean is not *invertible*.
-However, if we return the additional degree of freedom alongside the geometric mean (`dof`), then we do have an invertible function:
+However, if we return the additional degree of freedom alongside the geometric mean (`u`), then we do have an invertible function:
 ```julia
 function merge_means(m1, m2)
     m = sqrt(m1 * m2)
-    dof = m1 / (m1 + m2)
-    (m, dof)
+    u = m1 / (m1 + m2)
+    (m, u)
 end
 ```
 The inverse function is:
 ```julia
-function split_mean(m, dof)
-    m1 = m * sqrt((dof / (1 - dof)))
-    m2 = m * sqrt(((1 - dof) / dof))
+function split_mean(m, u)
+    m1 = m * sqrt((u / (1 - u)))
+    m2 = m * sqrt(((1 - u) / u))
     (m1, m2)
 end
 ```
@@ -301,7 +301,7 @@ The proposal is responsible for generating the extra degree of freedom when spli
         # currently two segments, switch to one
     else
         # currently one segment, switch to two
-        {:dof} ~ uniform_continuous(0, 1)
+        {:u} ~ uniform_continuous(0, 1)
     end
 end
 ```


### PR DESCRIPTION
In the involutive MCMC exmaple, :dof and :u are changed to :u as in GenExamples.jl