### PR TITLE
return incremental weights from particle filter step

### DIFF
--- a/src/inference/particle_filter.jl
+++ b/src/inference/particle_filter.jl
@@ -108,7 +108,7 @@ function initialize_particle_filter(model::GenerativeFunction{T,U}, model_args::
 end
 
 """
-    log_incremental_weights = particle_filter_step!(
+    (log_incremental_weights,) = particle_filter_step!(
         state::ParticleFilterState, new_args::Tuple, argdiffs,
         observations::ChoiceMap, proposal::GenerativeFunction, proposal_args::Tuple)
 
@@ -153,11 +153,11 @@ function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, a
     state.traces = state.new_traces
     state.new_traces = tmp
 
-    return log_incremental_weights
+    return (log_incremental_weights,)
 end
 
 """
-    log_incremental_weights = particle_filter_step!(
+    (log_incremental_weights,) = particle_filter_step!(
         state::ParticleFilterState, new_args::Tuple, argdiffs,
         observations::ChoiceMap)
 
@@ -182,7 +182,7 @@ function particle_filter_step!(state::ParticleFilterState{U}, new_args::Tuple, a
     state.traces = state.new_traces
     state.new_traces = tmp
 
-    return log_incremental_weights
+    return (log_incremental_weights,)
 end
 
 """

--- a/test/inference/particle_filter.jl
+++ b/test/inference/particle_filter.jl
@@ -132,7 +132,7 @@ end
         new_args = (T,)
         observations = choicemap((:chain => (T-1) => :x, obs_x[T]))
         proposal_args = (T, obs_x[T])
-        log_incremental_weights = particle_filter_step!(state, new_args, argdiffs, observations,
+        log_incremental_weights, = particle_filter_step!(state, new_args, argdiffs, observations,
             step_proposal, proposal_args)
         @test length(log_incremental_weights) == num_particles
     end
@@ -159,7 +159,7 @@ end
         maybe_resample!(state, ess_threshold=ess_threshold)
         new_args = (T,)
         observations = choicemap((:chain => (T-1) => :x, obs_x[T]))
-        log_incremental_weights = particle_filter_step!(state, new_args, argdiffs, observations)
+        log_incremental_weights, = particle_filter_step!(state, new_args, argdiffs, observations)
         @test length(log_incremental_weights) == num_particles
     end
 

--- a/test/inference/particle_filter.jl
+++ b/test/inference/particle_filter.jl
@@ -132,8 +132,9 @@ end
         new_args = (T,)
         observations = choicemap((:chain => (T-1) => :x, obs_x[T]))
         proposal_args = (T, obs_x[T])
-        particle_filter_step!(state, new_args, argdiffs, observations,
+        log_incremental_weights = particle_filter_step!(state, new_args, argdiffs, observations,
             step_proposal, proposal_args)
+        @test length(log_incremental_weights) == num_particles
     end
 
     # check log marginal likelihood estimate
@@ -158,7 +159,8 @@ end
         maybe_resample!(state, ess_threshold=ess_threshold)
         new_args = (T,)
         observations = choicemap((:chain => (T-1) => :x, obs_x[T]))
-        particle_filter_step!(state, new_args, argdiffs, observations)
+        log_incremental_weights = particle_filter_step!(state, new_args, argdiffs, observations)
+        @test length(log_incremental_weights) == num_particles
     end
 
     # check log marginal likelihood estimate


### PR DESCRIPTION
`Gen.particle_filter_step!` currently returns `nothing`. This PR makes it return the log incremental weight for each particle, which is useful for debugging and other purposes.