### PR TITLE
Use `==` rather than `===` to check gf equality

### DIFF
--- a/src/dynamic/update.jl
+++ b/src/dynamic/update.jl
@@ -86,7 +86,7 @@ function traceat(state::GFUpdateState, gen_fn::GenerativeFunction{T,U},
     if has_previous
         prev_call = get_call(state.prev_trace, key)
         prev_subtrace = prev_call.subtrace
-        get_gen_fn(prev_subtrace) === gen_fn || gen_fn_changed_error(key)
+        get_gen_fn(prev_subtrace) == gen_fn || gen_fn_changed_error(key)
         (subtrace, weight, _, discard) = update(prev_subtrace,
             args, map((_) -> UnknownChange(), args), constraints)
     else


### PR DESCRIPTION
I was running into an issue with using a generative function which looked like
```
@gen function foo()
  x ~ CustomCombinator(args)(...)
end
```
because each time the function was run, a new `CustomCombinator` was constructed, which was not always equal by reference (`===`) to the original one which had been constructed.  Resultantly, Gen threw an error saying the underlying generative function had changed.  If instead `==` were used, Gen would not have thrown an error, as the combinator was always equal by value.

This is not a huge deal -- one can just assign `CustomCombinator(args)` to a variable name globally, rather than constructing it within the generative function.  But it seems that the semantics we want for generative function equality checking is by value, not reference, and thus it would be the right call to change to `==` and fix this issue.