### PR TITLE
Allow SML functions to be generated by macros

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -461,7 +461,7 @@ The functions are also subject to the following restrictions:
 
 - Default argument values are not supported.
 
-- Julia closures are not allowed.
+- Constructing named or anonymous Julia functions (and closures) is not allowed.
 
 - List comprehensions with internal `@trace` calls are not allowed.
 

--- a/src/dsl/dsl.jl
+++ b/src/dsl/dsl.jl
@@ -147,7 +147,7 @@ function parse_gen_function(ast, annotations, __module__)
     return_type = get(def, :rtype, :Any)
     static = DSL_STATIC_ANNOTATION in annotations
     if static
-        make_static_gen_function(name, args, body, return_type, annotations)
+        make_static_gen_function(name, args, body, return_type, annotations, __module__)
     else
         args = map(a -> resolve_grad_arg(a, __module__), args)
         make_dynamic_gen_function(name, args, body, return_type, annotations)

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -101,7 +101,7 @@ function parse_trace_expr!(stmts, bindings, fn, args, addr, __module__)
     return name
 end
 
-function set_external_vars_module(expr, bindings, __module__)
+function set_module_for_global_constants(expr, bindings, __module__)
     expr = MacroTools.postwalk(expr) do e
         if MacroTools.@capture(e, var_Symbol) && !haskey(bindings, var) && var != :end
             :($__module__.$var)
@@ -119,7 +119,7 @@ function parse_julia_expr!(stmts, bindings, name::Symbol, expr::Expr,
     inputs = collect(resolved)
     input_vars = map((x) -> x[1], inputs)
     input_nodes = map((x) -> esc(x[2]), inputs)
-    expr = set_external_vars_module(expr, bindings, __module__)
+    expr = set_module_for_global_constants(expr, bindings, __module__)
     fn = Expr(:function, Expr(:tuple, input_vars...), expr)
     node = gensym(name)
     push!(stmts, :($(esc(node)) = add_julia_node!(

--- a/src/dsl/static.jl
+++ b/src/dsl/static.jl
@@ -58,7 +58,7 @@ gen_node_name(arg::Symbol) = gensym(arg)
 gen_node_name(arg::QuoteNode) = gensym(string(arg.value))
 
 "Parse @trace expression and add corresponding node to IR."
-function parse_trace_expr!(stmts, bindings, fn, args, addr)
+function parse_trace_expr!(stmts, bindings, fn, args, addr, __module__)
     expr_s = "@trace($fn($(join(args, ", "))), $addr)"
     name = gen_node_name(addr) # Each @trace node is named after its address
     node = gen_node_name(addr) # Generate a variable name for the StaticIRNode
@@ -91,7 +91,7 @@ function parse_trace_expr!(stmts, bindings, fn, args, addr)
         # Create Julia node for each argument to gen_fn_or_dist
         arg_name = gen_node_name(arg_expr)
         push!(inputs, parse_julia_expr!(stmts, bindings,
-            arg_name, arg_expr, QuoteNode(Any)))
+            arg_name, arg_expr, QuoteNode(Any), __module__))
     end
     # Add addr node (a GenerativeFunctionCallNode or RandomChoiceNode)
     push!(stmts, :($(esc(node)) = add_addr_node!(
@@ -101,14 +101,26 @@ function parse_trace_expr!(stmts, bindings, fn, args, addr)
     return name
 end
 
+function set_external_vars_module(expr, bindings, __module__)
+    expr = MacroTools.postwalk(expr) do e
+        if MacroTools.@capture(e, var_Symbol) && !haskey(bindings, var) && var != :end
+            :($__module__.$var)
+        else
+            e
+        end
+    end
+    return expr
+end
+
 "Parse a Julia expression and add a corresponding node to the IR."
 function parse_julia_expr!(stmts, bindings, name::Symbol, expr::Expr,
-                           typ::Union{Symbol,Expr,QuoteNode})
+                           typ::Union{Symbol,Expr,QuoteNode}, __module__)
     resolved = resolve_symbols(bindings, expr)
     inputs = collect(resolved)
-    input_vars = map((x) -> esc(x[1]), inputs)
+    input_vars = map((x) -> x[1], inputs)
     input_nodes = map((x) -> esc(x[2]), inputs)
-    fn = Expr(:function, Expr(:tuple, input_vars...), esc(expr))
+    expr = set_external_vars_module(expr, bindings, __module__)
+    fn = Expr(:function, Expr(:tuple, input_vars...), expr)
     node = gensym(name)
     push!(stmts, :($(esc(node)) = add_julia_node!(
         builder, $fn, inputs=[$(input_nodes...)], name=$(QuoteNode(name)),
@@ -117,17 +129,17 @@ function parse_julia_expr!(stmts, bindings, name::Symbol, expr::Expr,
 end
 
 function parse_julia_expr!(stmts, bindings, name::Symbol, var::Symbol,
-                           typ::Union{Symbol,Expr,QuoteNode})
+                           typ::Union{Symbol,Expr,QuoteNode}, __module__)
     if haskey(bindings, var)
         # Use the existing node instead of creating a new one
         return bindings[var]
     end
-    node = parse_julia_expr!(stmts, bindings, name, Expr(:block, var), typ)
+    node = parse_julia_expr!(stmts, bindings, name, :($__module__.$var), typ, __module__)
     return node
 end
 
 function parse_julia_expr!(stmts, bindings, name::Symbol, var::QuoteNode,
-                           typ::Union{Symbol,Expr,QuoteNode})
+                           typ::Union{Symbol,Expr,QuoteNode}, __module__)
     fn = Expr(:function, Expr(:tuple), var)
     node = gensym(name)
     push!(stmts, :($(esc(node)) = add_julia_node!(
@@ -137,7 +149,7 @@ function parse_julia_expr!(stmts, bindings, name::Symbol, var::QuoteNode,
 end
 
 function parse_julia_expr!(stmts, bindings, name::Symbol, value,
-                           typ::Union{Symbol,Expr,QuoteNode})
+                           typ::Union{Symbol,Expr,QuoteNode}, __module__)
     fn = Expr(:function, Expr(:tuple), QuoteNode(value))
     node = gensym(name)
     push!(stmts, :($(esc(node)) = add_julia_node!(
@@ -159,23 +171,23 @@ function parse_param_line!(stmts::Vector{Expr}, bindings, name::Symbol, typ)
 end
 
 "Parse assignments and add corresponding nodes for the right-hand-side."
-function parse_assignment_line!(stmts, bindings, lhs, rhs)
+function parse_assignment_line!(stmts, bindings, lhs, rhs, __module__)
     if isa(lhs, Expr) && lhs.head == :tuple
         # Recursively handle tuple assignments
         name, typ = gen_node_name(rhs), QuoteNode(Any)
-        node = parse_julia_expr!(stmts, bindings, name, rhs, typ)
+        node = parse_julia_expr!(stmts, bindings, name, rhs, typ, __module__)
         bindings[name] = node
         for (i, lhs_i) in enumerate(lhs.args)
             # Assign lhs[i] = rhs[i]
             rhs_i = :($name[$i])
-            parse_assignment_line!(stmts, bindings, lhs_i, rhs_i)
+            parse_assignment_line!(stmts, bindings, lhs_i, rhs_i, __module__)
         end
     else
         # Handle single variable assignment (base case)
         (name::Symbol, typ) = parse_typed_var(lhs)
         # Generate new node name if name is already bound
         node_name = haskey(bindings, name) ? gensym(name) : name
-        node = parse_julia_expr!(stmts, bindings, node_name, rhs, typ)
+        node = parse_julia_expr!(stmts, bindings, node_name, rhs, typ, __module__)
         # Old bindings are overwritten with new nodes
         bindings[name] = node
     end
@@ -184,32 +196,32 @@ function parse_assignment_line!(stmts, bindings, lhs, rhs)
 end
 
 "Parse a return line and add corresponding return node."
-function parse_return_line!(stmts, bindings, expr)
+function parse_return_line!(stmts, bindings, expr, __module__)
     name, typ = gensym("return"), QuoteNode(Any)
-    node = parse_julia_expr!(stmts, bindings, name, expr, typ)
+    node = parse_julia_expr!(stmts, bindings, name, expr, typ, __module__)
     bindings[name] = node
     push!(stmts, :(set_return_node!(builder, $(esc(node)))))
     return Expr(:return, expr)
 end
 
 "Parse and rewrite expression if it matches an @trace call."
-function parse_and_rewrite_trace!(stmts, bindings, expr)
+function parse_and_rewrite_trace!(stmts, bindings, expr, __module__)
     if MacroTools.@capture(expr, e_gentrace)
         # Parse "@trace(f(xs...), addr)" and return fresh variable
         call, addr = expr.args
         if addr == nothing static_dsl_syntax_error(expr, "Address required.") end
         fn, args = call.args[1], call.args[2:end]
-        parse_trace_expr!(stmts, bindings, fn, args, something(addr))
+        parse_trace_expr!(stmts, bindings, fn, args, something(addr), __module__)
     else
         expr # Return expression unmodified
     end
 end
 
 "Parse line (i.e. top-level expression) of a static Gen function body."
-function parse_static_dsl_line!(stmts, bindings, line)
+function parse_static_dsl_line!(stmts, bindings, line, __module__)
     # Walk each line bottom-up, parsing and rewriting :gentrace expressions
     rewritten = MacroTools.postwalk(
-        e -> parse_and_rewrite_trace!(stmts, bindings, e), line)
+        e -> parse_and_rewrite_trace!(stmts, bindings, e, __module__), line)
     # If line is a top-level @trace call, we are done
     if MacroTools.@capture(line, e_gentrace) return end
     # Match and parse any other top-level expressions
@@ -220,10 +232,10 @@ function parse_static_dsl_line!(stmts, bindings, line)
         parse_param_line!(stmts, bindings, name, typ)
     elseif MacroTools.@capture(line, lhs_ = rhs_)
         # Parse "lhs = rhs"
-        parse_assignment_line!(stmts, bindings, lhs, rhs)
+        parse_assignment_line!(stmts, bindings, lhs, rhs, __module__)
     elseif MacroTools.@capture(line, return expr_)
         # Parse "return expr"
-        parse_return_line!(stmts, bindings, expr)
+        parse_return_line!(stmts, bindings, expr, __module__)
     elseif line isa LineNumberNode
         # Skip line number nodes
     else
@@ -234,18 +246,18 @@ end
 
 "Parse static Gen function body line by line."
 function parse_static_dsl_function_body!(
-    stmts::Vector{Expr}, bindings::Dict{Symbol,Symbol}, expr)
+    stmts::Vector{Expr}, bindings::Dict{Symbol,Symbol}, expr, __module__)
     # TODO: Use line number nodes to improve error messages in generated code
     if !(isa(expr, Expr) && expr.head == :block)
         static_dsl_syntax_error(expr)
     end
     for line in expr.args
-        parse_static_dsl_line!(stmts, bindings, line)
+        parse_static_dsl_line!(stmts, bindings, line, __module__)
     end
 end
 
 "Generates the code that builds the IR of a static Gen function."
-function make_static_gen_function(name, args, body, return_type, annotations)
+function make_static_gen_function(name, args, body, return_type, annotations, __module__)
     # Construct the builder for the intermediate representation (IR)
     stmts = Expr[]
     push!(stmts, :(bindings = Dict{Symbol, StaticIRNode}()))
@@ -265,7 +277,7 @@ function make_static_gen_function(name, args, body, return_type, annotations)
         bindings[arg.name] = node
     end
     # Parse function body and add corresponding nodes to the IR
-    parse_static_dsl_function_body!(stmts, bindings, body)
+    parse_static_dsl_function_body!(stmts, bindings, body, __module__)
     push!(stmts, :(ir = build_ir(builder)))
     expr = gensym("gen_fn_defn")
     # Handle function annotations (caching Julia nodes by default)

--- a/test/dsl/static_dsl.jl
+++ b/test/dsl/static_dsl.jl
@@ -95,11 +95,15 @@ end
 
 # for testing that Julia expressions inside SML functions can
 # depend on variables defined in external lexical scope
+module MyModuleC
+using Gen: @gen, @load_generated_functions
 external_var = 1
 @gen (static) function uses_external()
     return external_var + 1
 end
+
 @load_generated_functions()
+end
 
 @testset "static DSL" begin
 
@@ -627,8 +631,8 @@ Gen.load_generated_functions()
 @test get_retval(simulate(foo_in_macro, ())) == 2
 end # @testset
 
-@testset "using an externally-defined variable" begin
-@test uses_external() == 2
+@testset "global variables" begin
+@test MyModuleC.uses_external() == 2
 end
 
 end # @testset "static DSL"

--- a/test/modeling_library/unfold.jl
+++ b/test/modeling_library/unfold.jl
@@ -1,15 +1,15 @@
+std = 1.0
+
+@gen (static) function kernel(t::Int, x_prev::Float64, (grad)(alpha::Float64), (grad)(beta::Float64))
+    x = @trace(normal(x_prev * alpha + beta, std), :x)
+    return x
+end
+
+foo = Unfold(kernel)
+
+@load_generated_functions()
+
 @testset "unfold combinator" begin
-
-    std = 1.0
-
-    @gen (static) function kernel(t::Int, x_prev::Float64, (grad)(alpha::Float64), (grad)(beta::Float64))
-        x = @trace(normal(x_prev * alpha + beta, std), :x)
-        return x
-    end
-
-    Gen.load_generated_functions()
-
-    foo = Unfold(kernel)
 
     @testset "Julia call" begin
         @test length(foo(5, 0., 1.0, 1.0)) == 5


### PR DESCRIPTION
Previously there was a bug [here](https://github.com/probcomp/Gen.jl/blob/3669eb9db361972d0191a0b3e62eb8a06f4b158e/src/dsl/static.jl#L109-L111) that involved excess use of `esc` when constructing the anonymous Julia functions used to represent Julia computations in SML code.

This bug caused a `LoadError` when a macro returned a quoted expression that included a `@gen (static) function .. end` block that includes Julia expressions in the body, because the code that is returned is malformed due to having qualified symbols used as formal parameter names in the anonymous function definition:
```julia
macro make_bar(constant )
    return quote
        @gen (static) function bar(a, b)
            c = $constant
            d = c + a + b
            return d
        end
    end
end

@make_bar 1.0
```
The error was:
```
ERROR: LoadError: syntax: "Main.a" is not a valid function argument name around /home/marcoct/dev/gen_issue_test/minimal_example.jl:44
```
The code returned from the macro was:
```julia
begin
    #= /home/marcoct/dev/gen_issue_test/minimal_example.jl:44 =#
    begin
        var"#4#bindings" = Gen.Dict{Gen.Symbol, Gen.StaticIRNode}()
        var"#5#builder" = Gen.StaticIRBuilder()
        Gen.set_accepts_output_grad!(var"#5#builder", $(QuoteNode(false)))
        Main.:(var"##a#263") = Gen.add_argument_node!(var"#5#builder", name = :a, typ = :Any, compute_grad = $(QuoteNode(false)))
        Main.:(var"##b#264") = Gen.add_argument_node!(var"#5#builder", name = :b, typ = :Any, compute_grad = $(QuoteNode(false)))
        Main.:(var"##c#265") = Gen.add_julia_node!(var"#5#builder", function ()
                    $(QuoteNode(1.0))
                end, inputs = [], name = :c, typ = $(QuoteNode(:($(QuoteNode(Any))))))
        Main.:(var"##d#266") = Gen.add_julia_node!(var"#5#builder", function (Main.a, Main.b, Main.c)
                    Main.c + Main.a + Main.b
                end, inputs = [Main.:(var"##a#263"), Main.:(var"##b#264"), Main.:(var"##c#265")], name = :d, typ = $(QuoteNode(:($(QuoteNode(Any))))))
        Gen.set_return_node!(var"#5#builder", Main.:(var"##d#266"))
        var"#6#ir" = Gen.build_ir(var"#5#builder")
        begin
            $(Expr(:meta, :doc))
            Main.bar = Main.eval(Gen.generate_generative_function(var"#6#ir", :bar, $(QuoteNode(Gen.StaticIRGenerativeFunctionOptions(false, true)))))
        end
    end
end
```
The offending code expression was:
```
function (Main.a, Main.b, Main.c)
    Main.c + Main.a + Main.b
end
```
This PR removes these escapes to fix this issue. I think this error did not occur for SML functions that are not generated by macros because in that case escaping the argument names causes Julia macro-expansion to not produce a qualified name for these variables (since the `Main` module is the default module anyways, so a qualified name would be unnecessary).

However, that caused a regression, because the variables inside the body of the anomymous Julia function are then resolved relative to the `Gen` module if they are not bound in the local scope of the SML function:
```julia
module MyModule
using Gen: @gen, @load_generated_functions

external_var = 1
@gen (static) function uses_external()
    return external_var + 1
end

@load_generated_functions()

end
```
The generated code includes the anonymous Julia function
```
function () Gen.external_var + 1 end
```

This is fixed [here](https://github.com/probcomp/Gen.jl/blob/005d24199fe381ec21e47ba6dacff996c404e79f/src/dsl/static.jl#L122) by ensuring that all symbols that are not defined resolved within the local scope of the SML function are resolved relative to the module that includes the SML definition and not `Gen`.

Also, since this (and likely other places in the implementation) does not respect Julia's scoping rules for Julia function definitions that appear in the SML function body, this is clarified in the documentation [here](https://github.com/probcomp/Gen.jl/commit/93955065d18cb78dae56ea4887daa53fe48c986d).