### PR TITLE
Fix `logpdf_grad` for BroadcastedNormal.

### DIFF
--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -87,8 +87,8 @@ function logpdf_grad(::BroadcastedNormal,
     deriv_mu = -deriv_x
     deriv_std = -1. ./ std .+ abs2.(z) ./ std
     (unbroadcast_for_arg(x, deriv_x), 
-    unbroadcast_for_arg(mu, deriv_mu), 
-    unbroadcast_for_arg(std, deriv_std))
+     unbroadcast_for_arg(mu, deriv_mu), 
+     unbroadcast_for_arg(std, deriv_std))
 end
 
 unbroadcast_for_arg(::Real, grad) = sum(grad)

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -105,10 +105,11 @@ end
 function _unbroadcast_to_shape(target_shape::NTuple{target_ndims, Int},
                                full_arr::AbstractArray{T, full_ndims}
                          ) where {T, target_ndims, full_ndims}
-    @assert full_ndims >= target_ndims  
-    full_shape = size(full_arr)
-    dims=filter(i -> i > target_ndims || target_shape[i] == 1 && full_shape[i] > 1, 1:full_ndims)
-    dropdims(sum(full_arr; dims=dims); dims=tuple((target_ndims+1:full_ndims)...))::AbstractArray{T, target_ndims}
+    @assert full_ndims >= target_ndims
+    should_sum_dim(i) = (i > target_ndims) || (target_shape[i] == 1 &&
+                                               size(full_arr, i) > 1)
+    dropdims(sum(full_arr; dims=filter(should_sum_dim, 1:full_ndims));
+             dims=Dims(target_ndims + 1 : full_ndims))
 end
 
 random(::Normal, mu::Real, std::Real) = mu + std * randn()

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -85,7 +85,7 @@ function logpdf_grad(::BroadcastedNormal,
     z = (x .- mu) ./ std
     deriv_x = - z ./ std
     deriv_mu = -deriv_x
-    deriv_std = -1. ./ std .+ abs2(z) ./ std
+    deriv_std = -1. ./ std .+ abs2.(z) ./ std
     (unbroadcast_for_arg(x, deriv_x), 
     unbroadcast_for_arg(mu, deriv_mu), 
     unbroadcast_for_arg(std, deriv_std))

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -93,13 +93,13 @@ end
 
 _unbroadcast_like(::Real, full_arr) = sum(full_arr)
 _unbroadcast_like(::AbstractArray{<:Real, 0}, full_arr::Real) = fill(full_arr)
-function _unbroadcast_like(arg::AbstractArray{<:Real, N},
+function _unbroadcast_like(a::AbstractArray{<:Real, N},
                            full_arr::AbstractArray{T}
                           )::AbstractArray{T, N} where {N,T}
-    if size(arg) == size(full_arr)
+    if size(a) == size(full_arr)
         return full_arr
     end
-    return _unbroadcast_to_shape(size(arg), full_arr)
+    return _unbroadcast_to_shape(size(a), full_arr)
 end
 
 """

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -34,7 +34,7 @@ Samples an `Array{Float64, max(N1, N2)}` of shape
 `Broadcast.broadcast_shapes(size(mu), size(std))` where each element is
 independently normally distributed.  This is equivalent to (a reshape of) a
 multivariate normal with diagonal covariance matrix, but its implementation is
-more efficient than that of the more general `mvnormal` for this case.
+more efficient than that of the more general [`mvnormal`](@ref) for this case.
 
 The shapes of `mu` and `std` must be broadcast-compatible.
 

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -96,7 +96,10 @@ _unbroadcast_like(::AbstractArray{<:Real, 0}, full_arr::Real) = fill(full_arr)
 function _unbroadcast_like(arg::AbstractArray{<:Real, N},
                            full_arr::AbstractArray{T}
                           )::AbstractArray{T, N} where {N,T}
-    size(arg) == size(full_arr) ? full_arr : _unbroadcast_to_shape(size(arg), full_arr)
+    if size(arg) == size(full_arr)
+        return full_arr
+    end
+    return _unbroadcast_to_shape(size(arg), full_arr)
 end
 
 function _unbroadcast_to_shape(target_shape::NTuple{target_ndims, Int},

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -102,6 +102,19 @@ function _unbroadcast_like(arg::AbstractArray{<:Real, N},
     return _unbroadcast_to_shape(size(arg), full_arr)
 end
 
+"""
+"Unbroadcasts" `full_arr` to have shape `target_shape` by:
+
+* Summing over all dims that would be increased by a broadcast from shape
+  `target_shape` to shape `size(full_arr)`
+* Then dropping trailing dims (which will all be 1's) as needed so that the
+  result has shape `target_shape`.
+
+Requires that `size(full_arr)` is "strictly bigger" than `target_shape`, in the
+sense that
+
+    Broadcast.broadcast_shapes(target_shape, size(full_arr)) == size(full_arr)
+"""
 function _unbroadcast_to_shape(target_shape::NTuple{target_ndims, Int},
                                full_arr::AbstractArray{T, full_ndims}
                          ) where {T, target_ndims, full_ndims}

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -86,14 +86,14 @@ function logpdf_grad(::BroadcastedNormal,
     deriv_x = - z ./ std
     deriv_mu = -deriv_x
     deriv_std = -1. ./ std .+ abs2.(z) ./ std
-    (unbroadcast_for_arg(x, deriv_x), 
-     unbroadcast_for_arg(mu, deriv_mu), 
-     unbroadcast_for_arg(std, deriv_std))
+    (_unbroadcast_for_arg(x, deriv_x), 
+     _unbroadcast_for_arg(mu, deriv_mu), 
+     _unbroadcast_for_arg(std, deriv_std))
 end
 
-unbroadcast_for_arg(::Real, grad) = sum(grad)
-unbroadcast_for_arg(::Array{Float64, 0}, grad::Real) = fill(grad)
-function unbroadcast_for_arg(
+_unbroadcast_for_arg(::Real, grad) = sum(grad)
+_unbroadcast_for_arg(::Array{Float64, 0}, grad::Real) = fill(grad)
+function _unbroadcast_for_arg(
     arg::AbstractArray{<:Real, N}, grad::AbstractArray{T}
 )::AbstractArray{T, N} where {N,T}
     size(arg) == size(grad) ? grad : unbroadcast_grad(size(arg), grad)

--- a/src/modeling_library/distributions/normal.jl
+++ b/src/modeling_library/distributions/normal.jl
@@ -93,15 +93,15 @@ end
 
 _unbroadcast_for_arg(::Real, grad) = sum(grad)
 _unbroadcast_for_arg(::Array{Float64, 0}, grad::Real) = fill(grad)
-function _unbroadcast_for_arg(
-    arg::AbstractArray{<:Real, N}, grad::AbstractArray{T}
-)::AbstractArray{T, N} where {N,T}
+function _unbroadcast_for_arg(arg::AbstractArray{<:Real, N},
+                              grad::AbstractArray{T}
+                             )::AbstractArray{T, N} where {N,T}
     size(arg) == size(grad) ? grad : unbroadcast_grad(size(arg), grad)
 end
 
-function unbroadcast_grad(
-    old_shape::NTuple{l_old, Int}, grad::AbstractArray{T, l_new}
-) where {T, l_old, l_new}
+function unbroadcast_grad(old_shape::NTuple{l_old, Int},
+                          grad::AbstractArray{T, l_new}
+                         ) where {T, l_old, l_new}
     @assert l_new >= l_old  
     new_shape = size(grad)
     dims=filter(i -> i > l_old || old_shape[i] == 1 && new_shape[i] > 1, 1:l_new)

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -123,12 +123,12 @@ end
     x = broadcasted_normal(fill(0), fill(1))
 
     # logpdf_grad
-    f = (x, mu, std) -> logpdf(broadcasted_normal, x, mu, std)
+    f(x, mu, std) = logpdf(broadcasted_normal, x, mu, std)
     args = (fill(0.4), fill(0.2), fill(0.3))
     actual = logpdf_grad(broadcasted_normal, args...)
-    @test isapprox(actual[1][], finite_diff(f, args, 1, dx))
-    @test isapprox(actual[2][], finite_diff(f, args, 2, dx))
-    @test isapprox(actual[3][], finite_diff(f, args, 3, dx))
+    @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
+    @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
+    @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
 end
 
 @testset "array normal (trivially broadcasted: all args have same shape)" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -126,6 +126,11 @@ end
     f(x, mu, std) = logpdf(broadcasted_normal, x, mu, std)
     args = (fill(0.4), fill(0.2), fill(0.3))
     actual = logpdf_grad(broadcasted_normal, args...)
+
+    @test actual[1] isa AbstractArray && size(actual[1]) == ()
+    @test actual[2] isa AbstractArray && size(actual[2]) == ()
+    @test actual[3] isa AbstractArray && size(actual[3]) == ()
+
     @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
     @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
     @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
@@ -147,6 +152,11 @@ end
     f(x_, mu_, std_) = logpdf(broadcasted_normal, x_, mu_, std_)
     args = (x, mu, std)
     actual = logpdf_grad(broadcasted_normal, args...)
+
+    @test actual[1] isa AbstractArray && size(actual[1]) == (2, 3)
+    @test actual[2] isa AbstractArray && size(actual[2]) == (2, 3)
+    @test actual[3] isa AbstractArray && size(actual[3]) == (2, 3)
+
     @test isapprox(actual[1], finite_diff_arr_fullarg(f, args, 1, dx); rtol=1e-7)
     @test isapprox(actual[2], finite_diff_arr_fullarg(f, args, 2, dx); rtol=1e-7)
     @test isapprox(actual[3], finite_diff_arr_fullarg(f, args, 3, dx); rtol=1e-7)

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -192,7 +192,8 @@ end
     @test_throws DimensionMismatch logpdf_grad(broadcasted_normal,
                                                ones(2, 1), ones(1,2), ones(1,3))
 
-    ## Equivalence of broadcast to supplying bigger arrays for `mu` and `std`
+    ## For `logpdf`, equivalence of broadcast to supplying bigger arrays for
+    ## `mu` and `std`
     compact = OrderedDict(:x => reshape([ 0.2  0.3  0.4  0.5 ;
                                           0.5  0.4  0.3  0.2 ],
                                         (2, 4)),

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -167,7 +167,12 @@ end
     ## Return shape of `broadcasted_normal`
     @test size(broadcasted_normal([0. 0. 0.], 1.)) == (1, 3)
     @test size(broadcasted_normal(zeros(1, 3, 4), ones(2, 1, 4))) == (2, 3, 4)
+    @test size(broadcasted_normal(zeros(1, 3), ones(2, 1, 1))) == (2, 3, 1)
     @test_throws DimensionMismatch broadcasted_normal([0 0 0], [1 1])
+    # Numpy and Julia use different conventions for which direction the
+    # implicit 1-padding goes.  In Julia, it's not `(1, 2, 3)` but rather
+    # `(2, 3, 1)` that is broadcast-compatible with the shape `(2, 3)`.
+    @test_throws DimensionMismatch broadcasted_normal(zeros(2, 3), ones(1, 2, 3))
 
     ## Return shape of `logpdf` and `logpdf_grad`
     @test size(logpdf(broadcasted_normal,
@@ -196,14 +201,14 @@ end
     ## `mu` and `std`
     compact = OrderedDict(:x => reshape([ 0.2  0.3  0.4  0.5 ;
                                           0.5  0.4  0.3  0.2 ],
-                                        (2, 4)),
+                                        (2, 4, 1)),
                           :mu => reshape([0.7  0.7  0.8  0.6],
                                          (1, 4)),
                           :std => reshape([0.2, 0.1],
-                                          (2, 1)))
+                                          (2, 1, 1)))
     expanded = OrderedDict(:x => compact[:x],
-                           :mu => repeat(compact[:mu], outer=(2, 1)),
-                           :std => repeat(compact[:std], outer=(1, 4)))
+                           :mu => repeat(compact[:mu], outer=(2, 1, 1)),
+                           :std => repeat(compact[:std], outer=(1, 4, 1)))
     @test (logpdf(broadcasted_normal, values(compact)...) ==
            logpdf(broadcasted_normal, values(expanded)...))
 end

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -144,12 +144,12 @@ end
     broadcasted_normal(mu, std)
 
     # logpdf_grad
-    f = (x, mu, std) -> logpdf(broadcasted_normal, x, mu, std)
-    args = (mu, std, x)
+    f(x_, mu_, std_) = logpdf(broadcasted_normal, x_, mu_, std_)
+    args = (x, mu, std)
     actual = logpdf_grad(broadcasted_normal, args...)
-    @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
-    @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
-    @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
+    @test isapprox(actual[1], finite_diff_arr_fullarg(f, args, 1, dx); rtol=1e-7)
+    @test isapprox(actual[2], finite_diff_arr_fullarg(f, args, 2, dx); rtol=1e-7)
+    @test isapprox(actual[3], finite_diff_arr_fullarg(f, args, 3, dx); rtol=1e-7)
 end
 
 @testset "broadcasted normal" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -126,9 +126,9 @@ end
     f = (x, mu, std) -> logpdf(broadcasted_normal, x, mu, std)
     args = (fill(0.4), fill(0.2), fill(0.3))
     actual = logpdf_grad(broadcasted_normal, args...)
-    @test isapprox(actual[1], finite_diff(f, args, 1, dx; broadcast=true))
-    @test isapprox(actual[2], finite_diff(f, args, 2, dx; broadcast=true))
-    @test isapprox(actual[3], finite_diff(f, args, 3, dx; broadcast=true))
+    @test isapprox(actual[1][], finite_diff(f, args, 1, dx))
+    @test isapprox(actual[2][], finite_diff(f, args, 2, dx))
+    @test isapprox(actual[3][], finite_diff(f, args, 3, dx))
 end
 
 @testset "array normal (trivially broadcasted: all args have same shape)" begin

--- a/test/modeling_library/distributions.jl
+++ b/test/modeling_library/distributions.jl
@@ -162,9 +162,9 @@ end
     ## Return shape of `logpdf` and `logpdf_grad`
     @test size(logpdf(broadcasted_normal,
                       ones(2, 4), ones(2, 1), ones(1, 4))) == ()
-    @test all(size(g) == ()
-              for g in logpdf_grad(
-                  broadcasted_normal, ones(2, 4), ones(2, 1), ones(1, 4)))
+    @test [size(g) for g in logpdf_grad(
+                  broadcasted_normal, ones(2, 4), ones(2, 1), ones(1, 4))
+          ] == [(2, 4), (2, 1), (1, 4)]
     # `x` has the wrong shape
     @test_throws DimensionMismatch logpdf(broadcasted_normal,
                                           ones(1, 2), ones(1,3), ones(2,1))
@@ -195,8 +195,6 @@ end
                            :std => repeat(compact[:std], outer=(1, 4)))
     @test (logpdf(broadcasted_normal, values(compact)...) ==
            logpdf(broadcasted_normal, values(expanded)...))
-    @test (logpdf_grad(broadcasted_normal, values(compact)...) ==
-           logpdf_grad(broadcasted_normal, values(expanded)...))
 end
 
 @testset "multivariate normal" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,26 @@ function finite_diff_arr(f::Function, args::Tuple, i::Int, idx, dx::Float64)
     return (f(pos_args...) - f(neg_args...)) / (2. * dx)
 end
 
+"""
+Returns the partial derivatives of `f` with respect to all entries of
+`args[i]`.
+
+That is, returns an array of the same shape as `args[i]`, each entry of which
+is `finite_diff_arr` applied to the corresponding entry of `args[i]`.
+
+Requires that `args[i]` have nonzero rank.  Due to [1], handling
+zero-dimensional arrays properly in this function is not feasible; the caller
+should handle that case on their own.
+
+[1] https://github.com/JuliaLang/julia/issues/28866
+"""
+function finite_diff_arr_fullarg(f::Function, args::Tuple, i::Int, dx::Float64)
+    @assert args[i] isa AbstractArray
+    @assert ndims(args[i]) > 0
+    return [finite_diff_arr(f, args, i, idx, dx)
+            for idx in keys(args[i])]
+end
+
 const dx = 1e-6
 
 include("autodiff.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,13 @@ function finite_diff(f::Function, args::Tuple, i::Int, dx::Float64;
     if broadcast
         pos_args[i] = copy(args[i]) .+ dx
         neg_args[i] = copy(args[i]) .- dx
-        return (f(pos_args...) - f(neg_args...)) ./ (2. * dx)
+        ans = (f(pos_args...) - f(neg_args...)) ./ (2. * dx)
+        # Workaround for
+        # https://github.com/probcomp/Gen.jl/pull/433#discussion_r669958584
+        if args[i] isa AbstractArray && ndims(args[i]) == 0
+            return fill(ans)
+        end
+        return ans
     else
         pos_args[i] += dx
         neg_args[i] -= dx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ Returns the partial derivatives of `f` with respect to all entries of
 `args[i]`.
 
 That is, returns an array of the same shape as `args[i]`, each entry of which
-is `finite_diff_arr` applied to the corresponding entry of `args[i]`.
+is [`finite_diff_arr`](@ref) applied to the corresponding entry of `args[i]`.
 
 Requires that `args[i]` have nonzero rank.  Due to [1], handling
 zero-dimensional arrays properly in this function is not feasible; the caller


### PR DESCRIPTION
As requested by #432, this PR fixes the gradient of BroadcastedNormal for the non-scalar cases. 

