### PR TITLE
Fix #445

### DIFF
--- a/src/modeling_library/mixture.jl
+++ b/src/modeling_library/mixture.jl
@@ -114,7 +114,7 @@ function Gen.logpdf_grad(dist::HomogeneousMixture, x, weights, args...)
                     dims=dist.dims[i]+1)
                 grad_weights = reshape(
                     relative_weighted_densities,
-                    (1 for d in 1:dist.dims[i])..., length(dist.dims))
+                    (1 for d in 1:dist.dims[i])..., K)
             end
             push!(arg_grads, grads .* grad_weights)
         else


### PR DESCRIPTION
This fixes an issue that @fzaiser found and diagnosed with the `logpdf_grad` implementation of `HomogeneousMixture`. 

The bug is in a call to `reshape` which uses `length(dist.dims)` (the number of arguments to each component of the mixture distribution) rather than `K = length(weights)`, the number of mixture components.