### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ julia:
   - 1.4
   - 1.5
   - 1.6
+  - nightly
 
 jobs:
   include:
-    - stage: test
-      script:
-        - julia -e 'using Pkg; Pkg.build(); Pkg.test()'
     - stage: docs
       julia: 1.6
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 # See http://docs.travis-ci.com/user/languages/julia/ and https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#Hosting-Documentation-1
 # See status of Travis builds at https://travis-ci.org/probcomp/Gen
 
+# As of March 2022, Gen is not compatible with Julia 1.7,
+# due to a regression involving NamedTuples:
+# https://github.com/JuliaLang/julia/issues/43783
+# The fix is already in `nightly` and slated for 1.8;
+# hopefully it will also be backported 
+# to a future minor release of 1.7.
 language: julia
 julia:
-  - 1.4
-  - 1.5
-  - 1.6
+  - 1.3 # earliest supported version
+  - 1.6 # LTS
   - nightly
 
 jobs:


### PR DESCRIPTION
This PR does two things:

1. Changes the versions of Julia we test, from 1.4/1.5/1.6, to 1.3/1.6/nightly. Julia 1.3 is the oldest version we support, Julia 1.6 is the LTS version, and testing on nightly should alert us to any breaking changes (thanks @femtomc for the suggestion).
2. Removes the explicit 'test' build stage, which was running an duplicated suite of tests on Julia 1.4. Thanks @ztangent for finding other projects' `.travis.yml` files that we could compare to, to debug this issue.