### PR TITLE
Fix hashing for choicemaps

### DIFF
--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -304,6 +304,16 @@ function Base.:(==)(a::ChoiceMap, b::ChoiceMap)
     end
     return true
 end
+function Base.hash(a::ChoiceMap, h::UInt)
+    running_hash = h
+    for (addr, value) in get_values_shallow(a)
+        running_hash = Base.hash(addr, Base.hash(value, running_hash))
+    end
+    for (addr, submap) in get_submaps_shallow(a)
+        running_hash = Base.hash(addr, Base.hash(submap, running_hash))
+    end
+    return running_hash
+end
 
 function Base.isapprox(a::ChoiceMap, b::ChoiceMap)
     for (addr, value) in get_values_shallow(a)

--- a/src/choice_map.jl
+++ b/src/choice_map.jl
@@ -304,15 +304,20 @@ function Base.:(==)(a::ChoiceMap, b::ChoiceMap)
     end
     return true
 end
+
+# This is modeled after
+# https://github.com/JuliaLang/julia/blob/7bff5cdd0fab8d625e48b3a9bb4e94286f2ba18c/base/abstractdict.jl#L530-L537
+const hasha_seed = UInt === UInt64 ? 0x6d35bb51952d5539 : 0x952d5539
 function Base.hash(a::ChoiceMap, h::UInt)
-    running_hash = h
+    hv = hasha_seed
     for (addr, value) in get_values_shallow(a)
-        running_hash = Base.hash(addr, Base.hash(value, running_hash))
+        hv = xor(hv, hash(addr, hash(value)))
     end
     for (addr, submap) in get_submaps_shallow(a)
-        running_hash = Base.hash(addr, Base.hash(submap, running_hash))
+        hv = xor(hv, hash(addr, hash(submap)))
     end
-    return running_hash
+    
+    return hash(hv, h)
 end
 
 function Base.isapprox(a::ChoiceMap, b::ChoiceMap)

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -385,7 +385,7 @@ end
     d[choicemap((:x, 1))] = 2
     d[choicemap((:x, 2), (:y, 3))] = 5
     d[choicemap((:x, 3), (:y => :z, 4))] = 7
-    d[choicemap((:x, 3), (:y => :z, 5), (:y => :z, 2))] = 10
+    d[choicemap((:x, 3), (:y => :w, 5), (:y => :z, 2))] = 10
 
     @test !haskey(d, choicemap())
     @test !haskey(d, EmptyChoiceMap())
@@ -394,11 +394,28 @@ end
     @test d[choicemap((:x, 1))] == 2
     @test d[choicemap((:x, 2), (:y, 3))] == 5
     @test d[choicemap((:x, 3), (:y => :z, 4))] == 7
-    @test d[choicemap((:x, 3), (:y => :z, 5), (:y => :z, 2))] == 10
+    @test d[choicemap((:x, 3), (:y => :w, 5), (:y => :z, 2))] == 10
+
+    # test that we can change the order and it still works
+    @test d[choicemap((:y, 3), (:x, 2))] == 5
+    @test d[choicemap((:y => :z, 4), (:x, 3))] == 7
+    @test d[choicemap((:y => :z, 2), (:y => :w, 5), (:x, 3))] == 10
 
     @test d[StaticChoiceMap(choicemap((:x, 1)))] == 2
 
     e = Dict()
     e[EmptyChoiceMap()] = 10
     @test e[choicemap()] == 10
+
+    # Non-exhaustive test that choicemap hash values don't collide too often.
+    # (This test works just by making sure that none of the 4 choicemaps used as keys
+    # in `d` collide; we may be able to come up with choicemaps that are more likely
+    # to collide if we think about it more.)
+    for a in keys(d)
+        for b in keys(d)
+            if a != b
+                @test hash(a) != hash(b)
+            end
+        end
+    end
 end

--- a/test/assignment.jl
+++ b/test/assignment.jl
@@ -379,3 +379,26 @@ end
     try c = choicemap((:a, 1, :b, 2)) catch Exception threw = true end
     @test threw
 end
+
+@testset "choicemap hashing" begin
+    d = Dict()
+    d[choicemap((:x, 1))] = 2
+    d[choicemap((:x, 2), (:y, 3))] = 5
+    d[choicemap((:x, 3), (:y => :z, 4))] = 7
+    d[choicemap((:x, 3), (:y => :z, 5), (:y => :z, 2))] = 10
+
+    @test !haskey(d, choicemap())
+    @test !haskey(d, EmptyChoiceMap())
+    @test !haskey(d, choicemap((:a, 3)))
+    @test !haskey(d, choicemap((:x, 2)))
+    @test d[choicemap((:x, 1))] == 2
+    @test d[choicemap((:x, 2), (:y, 3))] == 5
+    @test d[choicemap((:x, 3), (:y => :z, 4))] == 7
+    @test d[choicemap((:x, 3), (:y => :z, 5), (:y => :z, 2))] == 10
+
+    @test d[StaticChoiceMap(choicemap((:x, 1)))] == 2
+
+    e = Dict()
+    e[EmptyChoiceMap()] = 10
+    @test e[choicemap()] == 10
+end


### PR DESCRIPTION
This adds a method `Base.hash(::ChoiceMap)` to Gen, so that (e.g.) choicemaps can be used as keys in dictionaries.

Before this change, the following behavior would occur:
```
julia> d = Dict(); d[choicemap((:x, 1))] = 2;
julia> haskey(d, choicemap((:x, 1)))
false
```

Per [the Julia documentation](https://docs.julialang.org/en/v1/base/base/#Base.hash), since Gen implements a custom method `Base.:(==)(::ChoiceMap, ::ChoiceMap)`, it should also implement a custom hashing method with the property that `a::ChoiceMap == b::ChoiceMap` implies that `hash(a, h) == hash(b, h)` for any partial hash `h::UInt`.