### PR TITLE
Unexport `ifelse` to avoid conflicts with `Core.ifelse`.

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -412,5 +412,3 @@ end
 function ifelse(c::Bool, x, y)
     c ? x : y
 end
-
-export ifelse


### PR DESCRIPTION
Per #431, we should avoid exporting `Gen.ifelse` to avoid conflicts with `Core.ifelse`. Having searched through the code for the Gen ecosystem, it looks no tests make use of `Gen.ifelse`, and [only one example in GenExamples.jl](https://github.com/probcomp/GenExamples.jl/blob/6bc4a840fe6d823e008c1c4bf69e67ae1076e18e/regression/static_model.jl) makes use of it with an explicit import. It should thus be safe to unexport.