### PR TITLE
Eliminate the need for `@load_generated_functions`.

### DIFF
--- a/docs/src/ref/modeling.md
+++ b/docs/src/ref/modeling.md
@@ -427,7 +427,6 @@ This will produce a file `test.pdf` in the current working directory containing 
 ### Restrictions
 
 First, the definition of a `(static)` generative function is always expected to occur as a [top-level definition](https://docs.julialang.org/en/v1/manual/modules/) (aka global variable); usage in non–top-level scopes is unsupported and may result in incorrect behavior.
-Recall also that the macro [`@load_generated_functions`](@ref) is expected to be called as a top-level expression only.
 
 Next, in order to be able to construct the static graph, Gen restricts the permitted syntax that can be used in functions annotated with `static`.
 In particular, each statement in the body must be one of the following:
@@ -485,43 +484,8 @@ can instead be implemented as:
 ```
 
 ### Loading generated functions
-Before a function with a static annotation can be used, the [`@load_generated_functions`](@ref) macro must be called:
-```@docs
-@load_generated_functions
-```
-Typically, one call to this function, at the top level of a script, separates the definition of generative functions from the execution of inference code, e.g.:
-```julia
-using Gen: @load_generated_functions
 
-# define generative functions and inference code
-..
-
-# allow static generative functions defined above to be used
-@load_generated_functions()
-
-# run inference code
-..
-```
-
-When static generative functions are defined in a Julia module, [`@load_generated_functions`](@ref) should be called after all static functions are defined:
-
-```julia
-module MyModule
-using Gen
-# Include code that defines static generative functions
-include("my_static_gen_functions.jl")
-# Load generated functions defined in this module
-@load_generated_functions()
-end
-```
-
-Any script that imports or uses `MyModule` will then no longer need to call `@load_generated_functions` in order to use the static generative functions defined in that module:
-
-```julia
-using Gen
-using MyModule: my_static_gen_fn
-trace = simulate(my_static_gen_fn, ())
-```
+Once a `(static)` generative function is defined, it can be used in the same way as a non-static generative function. In previous versions of Gen, the `@load_generated_functions` macro had to be called before a function with a `(static)` annotation could be used. This macro is no longer necessary, and will be removed in a future release.
 
 ### Performance tips
 For better performance when the arguments are simple data types like `Float64`, annotate the arguments with the concrete type.

--- a/src/Gen.jl
+++ b/src/Gen.jl
@@ -2,34 +2,36 @@
 
 module Gen
 
-const generated_functions = []
-
 """
     load_generated_functions(__module__=Main)
 
-Permit use of generative functions written in the static modeling language up
-to this point. Functions are loaded into Main by default.
+!!! warning "Deprecation Warning"
+    Calling this function is no longer necessary in order to use the static
+    modeling language. This function will be removed in a future release.
+
+Previously, this permitted the use of generative functions written in the
+static modeling language by loading their associated function definitions into
+the specified module.
 """
 function load_generated_functions(__module__::Module=Main)
-    for function_defn in generated_functions
-        Core.eval(__module__, function_defn)
-    end
+    @warn "`Gen.load_generated_functions` is no longer necessary" *
+          " and will be removed in a future release."
 end
 
 """
     @load_generated_functions
 
-Permit use of generative functions written in the static modeling language up
-to this point. Functions are loaded into the calling module.
+!!! warning "Deprecation Warning"
+    Calling this macro is no longer necessary in order to use the static
+    modeling language. This macro will be removed in a future release.
 
-This macro is intended to be called as a
-[top-level expression](https://docs.julialang.org/en/v1/manual/modules/)
-only; use in non–top-level scopes may result in incorrect behavior.
+Previously, this permitted the use of generative functions written in the
+static modeling language by loading their associated function definitions into
+the calling module.
 """
 macro load_generated_functions()
-    for function_defn in generated_functions
-        Core.eval(__module__, function_defn)
-    end
+    @warn "`Gen.@load_generated_functions` is no longer necessary" *
+          " and will be removed in a future release."
 end
 
 export load_generated_functions, @load_generated_functions

--- a/src/Gen.jl
+++ b/src/Gen.jl
@@ -6,8 +6,8 @@ module Gen
     load_generated_functions(__module__=Main)
 
 !!! warning "Deprecation Warning"
-    Calling this function is no longer necessary in order to use the static
-    modeling language. This function will be removed in a future release.
+    As of Gen 0.4.6, this macro is no longer necessary in order to use the
+    static modeling language. It will be removed in a future release.
 
 Previously, this permitted the use of generative functions written in the
 static modeling language by loading their associated function definitions into
@@ -22,8 +22,8 @@ end
     @load_generated_functions
 
 !!! warning "Deprecation Warning"
-    Calling this macro is no longer necessary in order to use the static
-    modeling language. This macro will be removed in a future release.
+    As of Gen 0.4.6, this macro is no longer necessary in order to use the
+    static modeling language. It will be removed in a future release.
 
 Previously, this permitted the use of generative functions written in the
 static modeling language by loading their associated function definitions into

--- a/src/static_ir/backprop.jl
+++ b/src/static_ir/backprop.jl
@@ -496,17 +496,3 @@ function codegen_accumulate_param_gradients!(trace_type::Type{T},
 
     Expr(:block, stmts...)
 end
-
-
-push!(generated_functions, quote
-@generated function $(GlobalRef(Gen, :choice_gradients))(trace::T, selection::$(QuoteNode(Selection)),
-                                       retval_grad) where {T<:$(QuoteNode(StaticIRTrace))}
-    $(QuoteNode(codegen_choice_gradients))(trace, selection, retval_grad)
-end
-end)
-
-push!(generated_functions, quote
-@generated function $(GlobalRef(Gen, :accumulate_param_gradients!))(trace::T, retval_grad) where {T<:$(QuoteNode(StaticIRTrace))}
-    $(QuoteNode(codegen_accumulate_param_gradients!))(trace, retval_grad)
-end
-end)

--- a/src/static_ir/generate.jl
+++ b/src/static_ir/generate.jl
@@ -107,10 +107,3 @@ function codegen_generate(gen_fn_type::Type{T}, args,
 
     Expr(:block, stmts...)
 end
-
-push!(generated_functions, quote
-@generated function $(GlobalRef(Gen, :generate))(gen_fn::$(QuoteNode(StaticIRGenerativeFunction)),
-                                   args::$(QuoteNode(Tuple)), constraints::$(QuoteNode(ChoiceMap)))
-    $(QuoteNode(codegen_generate))(gen_fn, args, constraints)
-end
-end)

--- a/src/static_ir/project.jl
+++ b/src/static_ir/project.jl
@@ -53,15 +53,3 @@ function codegen_project(trace_type::Type, selection_type::Type)
 
     Expr(:block, stmts...)
 end
-
-push!(generated_functions, quote
-
-@generated function $(GlobalRef(Gen, :project))(trace::T, selection::$(QuoteNode(Selection))) where {T <: $(QuoteNode(StaticIRTrace))}
-    $(QuoteNode(codegen_project))(trace, selection)
-end
-
-function $(GlobalRef(Gen, :project))(trace::T, selection::$(QuoteNode(EmptySelection))) where {T <: $(QuoteNode(StaticIRTrace))}
-    trace.$total_noise_fieldname
-end
-
-end)

--- a/src/static_ir/simulate.jl
+++ b/src/static_ir/simulate.jl
@@ -81,9 +81,3 @@ function codegen_simulate(gen_fn_type::Type{T}, args) where {T <: StaticIRGenera
 
     Expr(:block, stmts...)
 end
-
-push!(generated_functions, quote
-@generated function $(GlobalRef(Gen, :simulate))(gen_fn::$(QuoteNode(StaticIRGenerativeFunction)), args::Tuple)
-    $(QuoteNode(codegen_simulate))(gen_fn, args)
-end
-end)

--- a/src/static_ir/update.jl
+++ b/src/static_ir/update.jl
@@ -554,19 +554,3 @@ function codegen_regenerate(trace_type::Type{T}, args_type::Type, argdiffs_type:
 
     Expr(:block, stmts...)
 end
-
-let T = gensym()
-    push!(generated_functions, quote
-    @generated function $(GlobalRef(Gen, :update))(trace::$T, args::Tuple, argdiffs::Tuple,
-                                   constraints::$(QuoteNode(ChoiceMap))) where {$T<:$(QuoteNode(StaticIRTrace))}
-        $(QuoteNode(codegen_update))(trace, args, argdiffs, constraints)
-    end
-    end)
-
-    push!(generated_functions, quote
-    @generated function $(GlobalRef(Gen, :regenerate))(trace::$T, args::Tuple, argdiffs::Tuple,
-                                       selection::$(QuoteNode(Selection))) where {$T<:$(QuoteNode(StaticIRTrace))}
-        $(QuoteNode(codegen_regenerate))(trace, args, argdiffs, selection)
-    end
-    end)
-end

--- a/test/dsl/macros.jl
+++ b/test/dsl/macros.jl
@@ -119,8 +119,6 @@ end
     @set_x_to_normal_traceexpr y # x = Gen.@trace(normal(y, 1), :y) USING EXPR(:GENTRACE)
 end
 
-@load_generated_functions()
-
 @testset "macros in static DSL" begin
     trace = simulate(foo1, ())
     @test trace[:y] != trace[:x]

--- a/test/gen_fn_interface.jl
+++ b/test/gen_fn_interface.jl
@@ -6,7 +6,6 @@ end
     z ~ normal(0, 1)
     return x + y + z
 end
-@load_generated_functions()
 
 for (lang, f) in [:dynamic => f_dynamic,
                   :static  => f_static]

--- a/test/modeling_library/unfold.jl
+++ b/test/modeling_library/unfold.jl
@@ -7,8 +7,6 @@ end
 
 foo = Unfold(kernel)
 
-@load_generated_functions()
-
 @testset "unfold combinator" begin
 
     @testset "Julia call" begin
@@ -529,9 +527,9 @@ foo = Unfold(kernel)
         @test isapprox(k_grads[2], 1024.0)
     end
 
-    @gen (grad) function kernel(t::Int, 
-            (grad)(x_prev::Float64), 
-            (grad)(alpha::Float64), 
+    @gen (grad) function kernel(t::Int,
+            (grad)(x_prev::Float64),
+            (grad)(alpha::Float64),
             (grad)(beta::Float64))
         x = @trace(normal(x_prev * alpha + beta, 1.0), :x)
         return x

--- a/test/static_ir/static_ir.jl
+++ b/test/static_ir/static_ir.jl
@@ -62,8 +62,6 @@ ir = build_ir(builder)
 const_fn = eval(generate_generative_function(ir, :const_fn, track_diffs=false, cache_julia_nodes=false))
 @test occursin("== Static IR ==", repr("text/plain", ir))
 
-Gen.load_generated_functions()
-
 @testset "Julia call" begin
     @test const_fn() == 2
 end
@@ -318,8 +316,6 @@ end
     ir = build_ir(builder)
     foo = eval(generate_generative_function(ir, :foo, track_diffs=false, cache_julia_nodes=false))
 
-    Gen.load_generated_functions()
-
     function f(mu_a, theta, a, b, z, out)
         lpdf = 0.
         mu_z = a
@@ -433,8 +429,6 @@ foo = eval(generate_generative_function(ir, :foo, track_diffs=true, cache_julia_
 # generate a version of the function without tracked diffs
 foo_without_tracked_diffs = eval(generate_generative_function(ir, :foo, track_diffs=false, cache_julia_nodes=false))
 
-Gen.load_generated_functions()
-
 @testset "update with tracked diffs" begin
 
     # generate initial trace from function with tracked diffs
@@ -524,8 +518,6 @@ set_return_node!(builder, x)
 ir = build_ir(builder)
 foo = eval(generate_generative_function(ir, :foo, track_diffs=false, cache_julia_nodes=true))
 
-Gen.load_generated_functions()
-
 @testset "cached julia nodes" begin
 
     counter = 0
@@ -563,7 +555,6 @@ end
         T = @trace(normal(mean, var), :T)
         return T
     end
-    load_generated_functions()
     selection = StaticSelection(select(:mean))
     (tr, _) = generate(model, (1,))
     # At the time the issue was filed, this line produced a crash

--- a/test/tilde_sugar.jl
+++ b/test/tilde_sugar.jl
@@ -31,8 +31,6 @@ end
         return {:ret} ~ poisson(retrate)
     end
 
-    Gen.load_generated_functions()
-
     trace = simulate(foo, ())
 
     # random choices
@@ -74,7 +72,6 @@ end
     @gen (static) function tilde_expr()
         return :(x ~ normal(0, 1))
     end
-    Gen.load_generated_functions()
     @test tilde_expr() == :(x ~ normal(0, 1))
 end
 


### PR DESCRIPTION
This PR eliminates the need to call `@load_generated_functions` in order to make use of a generative function written in the static modeling language. Instead, new `@generated` GFI methods (`simulate`, `update`, etc.) are defined for each static generative function. These GFI definitions are evaluated after the `get_ir` and `get_options` definitions returned by `Gen.generate_generative_function`, preventing world-age issues.

Besides making the static modeling language easier to use, this change prevents incremental precompilation warnings and breakages which were occurring when multiple sub-packages called `@load_generated_functions`, of the form:

```
WARNING: Method definition simulate(Gen.StaticIRGenerativeFunction{T, U} where U where T, Tuple)
in module TestSubPkgA at C:\...\Gen.jl\src\static_ir\simulate.jl:86 overwritten in module TestSubPkgB
on the same line (check for duplicate calls to `include`).
  ** incremental compilation may be fatally broken for this module **
```

Minimal working example: [TestPkg.zip](https://github.com/probcomp/Gen.jl/files/8910161/TestPkg.zip)

This warning occurs because `@generated function simulate(...)` was being defined multiple times:
1. Once when some dependency`TestSubPkgA` that calls `@load_generated_functions` is precompiled.
2. Again where another dependency `TestSubPkgB` that calls `@load_generated_functions` is precompiled.

The second definition overwrites the first definition for the exact same `@generated` method, leading to precompilation warnings. This PR addresses the issue by defining a *different* `@generated` method for each new generative function.

In addition to the main change:
- All tests have been updated to remove calls to `load_generated_functions` or `@load_generated_functions`.
- Deprecation warnings have been added to the docstrings and function bodies of those methods
- Documentation has been updated to reflect that calling `@load_generated_functions` is no longer necessary.
 
 For documentation and docstrings, we may want to specify a version number, e.g. Gen v0.4.6, for when `load_generated_functions` is no longer necessary. But apart from that, I'm pretty sure this is safe for the rest of the Gen ecosystem!