### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/inference/importance.jl
+++ b/src/inference/importance.jl
@@ -69,7 +69,7 @@ Setting `verbose=true` prints a progress message every sample.
 """
 function importance_resampling(model::GenerativeFunction{T,U}, model_args::Tuple,
                                observations::ChoiceMap,
-                               num_samples::Int; verbose=false)  where {T,U,V,W}
+                               num_samples::Int; verbose=false)  where {T,U}
     (model_trace::U, log_weight) = generate(model, model_args, observations)
     log_total_weight = log_weight
     for i=2:num_samples

--- a/src/modeling_library/switch/update.jl
+++ b/src/modeling_library/switch/update.jl
@@ -88,7 +88,7 @@ function process!(gen_fn::Switch{C, N, K, T},
         args::Tuple,
         kernel_argdiffs::Tuple,
         choices::ChoiceMap, 
-        state::SwitchUpdateState{T}) where {C, N, K, T, DV}
+        state::SwitchUpdateState{T}) where {C, N, K, T}
 
     # Generate new trace.
     merged = update_recurse_merge(get_choices(state.prev_trace), choices)


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608