### PR TITLE
Type signature of HeterogeneousMixture, Closes #500

### DIFF
--- a/src/modeling_library/mixture.jl
+++ b/src/modeling_library/mixture.jl
@@ -178,7 +178,7 @@ Gen.is_discrete(dist::HeterogeneousMixture) = dist.is_discrete
 
 const MIXTURE_WRONG_NUM_COMPONENTS_ERR = "the length of the weights vector does not match the number of mixture components"
 
-function HeterogeneousMixture(distributions::Vector{Distribution{T}}) where {T}
+function HeterogeneousMixture(distributions::Vector{D}) where {T, D <: Distribution{T}}
     _has_output_grad = true
     _has_argument_grads = Bool[true] # weights
     _is_discrete = true


### PR DESCRIPTION
Closes #500

You couldn't call `HeterogeneousMixture` on a vector of type `Vector{D}`, where `D` inherited from `Distributions{T}`. This should fix it.