### PR TITLE
Fix dirichlet type

### DIFF
--- a/src/modeling_library/distributions/dirichlet.jl
+++ b/src/modeling_library/distributions/dirichlet.jl
@@ -1,7 +1,7 @@
 struct Dirichlet <: Distribution{Vector{Float64}} end
 
 """
-    Dirichlet(alpha::Vector{Float64})
+    dirichlet(alpha::Vector{Float64})
 
 Sample a simplex Vector{Float64} from a Dirichlet distribution.
 """

--- a/src/modeling_library/distributions/dirichlet.jl
+++ b/src/modeling_library/distributions/dirichlet.jl
@@ -1,4 +1,4 @@
-struct Dirichlet <: Distribution{Float64} end
+struct Dirichlet <: Distribution{Vector{Float64}} end
 
 """
     Dirichlet(alpha::Vector{Float64})


### PR DESCRIPTION
Before

```julia
using Gen

@gen function rand_prob_vec()
    prob_vec ~ dirichlet([1.0 for _ in 1:3])
end

tr = simulate(rand_prob_vec, ())
```

throws

```
ERROR: MethodError: Cannot `convert` an object of type Vector{Float64} to an object of type Float64

Closest candidates are:
  convert(::Type{T}, ::DualNumbers.Dual) where T<:Union{Real, Complex}
   @ DualNumbers ~/.julia/packages/DualNumbers/5knFX/src/dual.jl:24
  convert(::Type{R}, ::T) where {R<:Real, T<:ReverseDiff.TrackedReal}
   @ ReverseDiff ~/.julia/packages/ReverseDiff/UJhiD/src/tracked.jl:260
  convert(::Type{T}, ::T) where T
   @ Base Base.jl:84
  ...

Stacktrace:
 [1] traceat(state::Gen.GFSimulateState, dist::Gen.Dirichlet, args::Tuple{Vector{Float64}}, key::Symbol)
   @ Gen ~/.julia/packages/Gen/ME5el/src/dynamic/simulate.jl:19
 [2] var"##rand_prob_vec#225"(state#227::Gen.GFSimulateState)
   @ Main ~/synthesis/frans/test_dirichlet.jl:4
 [3] exec(gen_fn::DynamicDSLFunction{Any}, state::Gen.GFSimulateState, args::Tuple{})
   @ Gen ~/.julia/packages/Gen/ME5el/src/dynamic/dynamic.jl:58
 [4] simulate(gen_fn::DynamicDSLFunction{Any}, args::Tuple{})
   @ Gen ~/.julia/packages/Gen/ME5el/src/dynamic/simulate.jl:61

```