### PR TITLE
Fix `has_argument_grads` for Poisson distribution.

### DIFF
--- a/src/modeling_library/distributions/poisson.jl
+++ b/src/modeling_library/distributions/poisson.jl
@@ -24,6 +24,6 @@ end
 is_discrete(::Poisson) = true
 
 has_output_grad(::Poisson) = false
-has_argument_grads(::Poisson) = (false,)
+has_argument_grads(::Poisson) = (true,)
 
 export poisson


### PR DESCRIPTION
Discovered in https://github.com/probcomp/Gen.jl/discussions/540#discussioncomment-10551055. The implementation of `has_argument_grads` mistakenly claimed that the gradient wasn't implemented for the first argument of the Poisson distribution.