### PR TITLE
Fix docstring tests on Julia nightly / 1.11.

### DIFF
--- a/test/dsl/dynamic_dsl.jl
+++ b/test/dsl/dynamic_dsl.jl
@@ -534,6 +534,16 @@ end
 
 @testset "docstrings" begin
 
+    function doc_to_str(doc)
+        if doc isa Base.Docs.DocStr
+            # Handle @doc behavior in Julia 1.11 when REPL is not loaded
+            return doc.text[1]
+        else
+            # Handle pre-Julia 1.11 behavior of @doc
+            return strip(string(doc))
+        end
+    end
+        
     """
     my documentation
     """
@@ -541,9 +551,7 @@ end
             return x + 1
     end
 
-    io = IOBuffer()
-    print(io, @doc foo)
-    @test String(take!(io)) == "my documentation\n"
+    @test doc_to_str(@doc(foo)) == "my documentation"
 
 end
 

--- a/test/dsl/dynamic_dsl.jl
+++ b/test/dsl/dynamic_dsl.jl
@@ -540,7 +540,7 @@ end
             return doc.text[1]
         else
             # Handle pre-Julia 1.11 behavior of @doc
-            return strip(string(doc))
+            return string(doc)
         end
     end
         
@@ -551,7 +551,7 @@ end
             return x + 1
     end
 
-    @test doc_to_str(@doc(foo)) == "my documentation"
+    @test doc_to_str(@doc(foo)) == "my documentation\n"
 
 end
 

--- a/test/dsl/static_dsl.jl
+++ b/test/dsl/static_dsl.jl
@@ -558,9 +558,16 @@ trace, = generate(foo, (), constraints)
 end
 
 @testset "docstrings" begin
-    io = IOBuffer()
-    print(io, @doc model)
-    @test String(take!(io)) == "my documentation\n"
+    function doc_to_str(doc)
+        if doc isa Base.Docs.DocStr
+            # Handle @doc behavior in Julia 1.11 when REPL is not loaded
+            return doc.text[1]
+        else
+            # Handle pre-Julia 1.11 behavior of @doc
+            return strip(string(doc))
+        end
+    end
+    @test doc_to_str(@doc(model)) == "my documentation\n"
 end
 
 @testset "one-line definitions" begin

--- a/test/dsl/static_dsl.jl
+++ b/test/dsl/static_dsl.jl
@@ -564,7 +564,7 @@ end
             return doc.text[1]
         else
             # Handle pre-Julia 1.11 behavior of @doc
-            return strip(string(doc))
+            return string(doc)
         end
     end
     @test doc_to_str(@doc(model)) == "my documentation\n"


### PR DESCRIPTION
This addresses #523 by handling the new return type of `@doc` on Julia 1.11 nightly builds when the REPL module isn't loaded, which differs from the behavior of `@doc` on earlier versions of Julia.